### PR TITLE
Fix __eq__ operator in Connection class

### DIFF
--- a/cloudmapper/nodes.py
+++ b/cloudmapper/nodes.py
@@ -390,8 +390,8 @@ class Connection(object):
     def __key(self):
         return (self._source.arn, self._target.arn)
 
-    def __eq__(self, x, y):
-        return x.__key() == y.__key()
+    def __eq__(self, other):
+        return self.__key() == other.__key()
 
     def __hash__(self):
         return hash(self.__key())


### PR DESCRIPTION
This is the most "standard" way of using the __eq__ operator, at least according to the doc https://docs.python.org/2/reference/datamodel.html. By making this change I was able to execute the prepare operation without problem, but I can't confirm it didn't change the previous behavior.