### PR TITLE
Show host/port when serving

### DIFF
--- a/cloudmapper/webserver.py
+++ b/cloudmapper/webserver.py
@@ -74,4 +74,5 @@ def run_webserver(arguments):
         listening_host = '127.0.0.1'
 
     httpd = RootedHTTPServer("web", (listening_host, args.port), MyHTTPRequestHandler)
+    print("CloudMapper serving on {}:{}".format(listening_host, args.port))
     httpd.serve_forever()


### PR DESCRIPTION
Otherwise you get no feedback and have to traverse the source to figure out what the default port is.