### PR TITLE
Add configure CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,16 @@ Using the script is helpful if you need someone else to get this data for you wi
 python cloudmapper.py gather --account-name my_account
 ```
 
-## 2. Prepare the data
+## 2. Generate your config file
+
+These steps allows you yo generate your own config file.
+```
+python cloudmapper.py {add-cidr|remove-cidr} --config-file CONFIG_FILE --cidr CIDR --name NAME
+python cloudmapper.py {add-account|remove-account} --config-file CONFIG_FILE --name NAME --id ID [--default DEFAULT]
+```
+
+This will allow you to define the different AWS accounts you use in your environment or the known CIDR IPs. See `config.json.demo` as an example.
+## 3. Prepare the data
 
 This step converts the collected AWS data into a format that can be displayed in the browser by generating a `web/data.json` file.
 ```
@@ -121,7 +130,7 @@ The other filtering options are:
 * `--azs` (default) and `--no-azs`: Availibility zones are shown by default.  To ignore them, use `--no-azs`.
 
 
-## 3. Run a webserver
+## 4. Run a webserver
 
 You can host the `web` directory with your webserver of choice, or just run:
 

--- a/cloudmapper.py
+++ b/cloudmapper.py
@@ -56,6 +56,34 @@ def run_gathering(arguments):
     gather(args)
 
 
+def run_configure(arguments):
+    from cloudmapper.configure import configure
+    if len(arguments) == 0:
+        exit("ERROR: Missing action for configure. Should be in {add-cidr|add-account|remove-cidr|remove-account}")
+        return
+    action = arguments[0]
+    arguments = arguments[1:]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config-file", help="Path to the config file",
+                        required=True, type=str)
+    if action == 'add-account' or action == 'remove-account':
+        required = True if action.startswith('add') else False
+        parser.add_argument("--name", help="Account name",
+                            required=required, type=str)
+        parser.add_argument("--id", help="Account ID",
+                        required=required, type=str)
+        parser.add_argument("--default", help="Default account",
+                        required=False, default="False", type=str)
+    elif action == 'add-cidr' or action == 'remove-cidr':
+        required = True if action.startswith('add') else False
+        parser.add_argument("--cidr", help="CIDR IP",
+                        required=required, type=str)
+        parser.add_argument("--name", help="CIDR Name",
+                        required=required, type=str)
+    args = parser.parse_args(arguments)
+    configure(action, args)
+
+
 def run_prepare(arguments):
     from cloudmapper.prepare import prepare
 
@@ -119,6 +147,7 @@ def run_prepare(arguments):
 def show_help():
     print("CloudMapper {}".format(__version__))
     print("usage: {} [gather|prepare|serve] [...]".format(sys.argv[0]))
+    print("  configure: Configure and create your config file")
     print("  gather: Queries AWS for account data and caches it locally")
     print("  prepare: Prepares the data for viewing")
     print("  serve: Runs a local webserver for viewing the data")
@@ -141,6 +170,8 @@ def main():
         run_webserver(arguments)
     elif command == "gather":
         run_gathering(arguments)
+    elif command == "configure":
+        run_configure(arguments)
     else:
         show_help()
 

--- a/cloudmapper.py
+++ b/cloudmapper.py
@@ -65,7 +65,7 @@ def run_configure(arguments):
     arguments = arguments[1:]
     parser = argparse.ArgumentParser()
     parser.add_argument("--config-file", help="Path to the config file",
-                        required=True, type=str)
+                        default="config.json", type=str)
     if action == 'add-account' or action == 'remove-account':
         required = True if action.startswith('add') else False
         parser.add_argument("--name", help="Account name",

--- a/cloudmapper/configure.py
+++ b/cloudmapper/configure.py
@@ -1,13 +1,12 @@
 import json
 import netaddr
-import six
 import os.path
 
 
 def configure(action, arguments):
     if not os.path.isfile(arguments.config_file):
         print("Config file does not exist, creating one")
-        config = {  "accounts": [], "cidrs": {}}
+        config = {"accounts": [], "cidrs": {}}
     else:
         with open(arguments.config_file, 'r') as f:
             config = json.loads(f.read())
@@ -39,13 +38,12 @@ def configure(action, arguments):
             condition = lambda x, y: x or y
         else:
             condition = lambda x, y: x and y
-        
+
         # Force it to be a complete set so that deleting the key later on doesn't raise an error because the dictionary Size changed during iteration
         for cidr in set(config['cidrs'].keys()):
             name = config['cidrs'][cidr]['name']
             if condition(cidr == arguments.cidr, name == arguments.name):
                 del config['cidrs'][cidr]
-    
+
     with open(arguments.config_file, 'w+') as f:
         f.write(json.dumps(config, indent=4, sort_keys=True))
-        

--- a/cloudmapper/configure.py
+++ b/cloudmapper/configure.py
@@ -1,0 +1,51 @@
+import json
+import netaddr
+import six
+import os.path
+
+
+def configure(action, arguments):
+    if not os.path.isfile(arguments.config_file):
+        print("Config file does not exist, creating one")
+        config = {  "accounts": [], "cidrs": {}}
+    else:
+        with open(arguments.config_file, 'r') as f:
+            config = json.loads(f.read())
+    if action == 'add-account':
+        config['accounts'].append({
+            "id": str(arguments.id),
+            "name": str(arguments.name),
+            "default": True if arguments.default.lower() == 'true' else False,
+        })
+    elif action == 'add-cidr':
+        try:
+            netaddr.IPNetwork(arguments.cidr)
+        except netaddr.core.AddrFormatError:
+            exit("ERROR: CIDR is not valid")
+            return
+        config['cidrs'][str(arguments.cidr)] = {
+            "name": str(arguments.name),
+        }
+    elif action == 'remove-account':
+        if arguments.name is None or arguments.id is None:
+            condition = lambda x, y: x or y
+        else:
+            condition = lambda x, y: x and y
+        for account in config['accounts']:
+            if condition(account['id'] == arguments.id, account['name'] == arguments.name):
+                config['accounts'].remove(account)
+    elif action == 'remove-cidr':
+        if arguments.name is None or arguments.cidr is None:
+            condition = lambda x, y: x or y
+        else:
+            condition = lambda x, y: x and y
+        
+        # Force it to be a complete set so that deleting the key later on doesn't raise an error because the dictionary Size changed during iteration
+        for cidr in set(config['cidrs'].keys()):
+            name = config['cidrs'][cidr]['name']
+            if condition(cidr == arguments.cidr, name == arguments.name):
+                del config['cidrs'][cidr]
+    
+    with open(arguments.config_file, 'w+') as f:
+        f.write(json.dumps(config, indent=4, sort_keys=True))
+        


### PR DESCRIPTION
Second try at solving https://github.com/duo-labs/cloudmapper/issues/3

I took your comment into account and the config CLI now works that way.

Tested with:
```
python cloudmapper.py configure add-account --config-file config.json --id 123456789012 --name demo --default True
python cloudmapper.py configure add-cidr --config-file config.json --cidr 2.2.2.2/28 --name "NY Office"
python cloudmapper.py configure add-cidr --config-file config.json --cidr 1.1.1.1/32 --name "SF Office"
python cloudmapper.py configure remove-cidr --config-file config.json --cidr 1.1.1.1/32
python cloudmapper.py configure remove-cidr --config-file config.json --name "SF Office"
python cloudmapper.py configure remove-cidr --config-file config.json --name "NY Office"
python cloudmapper.py configure remove-account --config-file config.json --id 123456789012
python cloudmapper.py configure add-account --config-file config.json --id 123456789012 --name demo --default True
python cloudmapper.py configure remove-account --config-file config.json --name demo
```