### PR TITLE
Added support for filter by vpc [id/name]

### DIFF
--- a/cloudmapper.py
+++ b/cloudmapper.py
@@ -60,7 +60,6 @@ def run_gathering(arguments):
     args = parser.parse_args(arguments)
 
     if not args.account_name:
-        print("No account name defined... getting from config")
         try:
             config = json.load(open(args.config))
         except IOError:
@@ -69,7 +68,6 @@ def run_gathering(arguments):
             exit("ERROR: Config file \"{}\" could not be loaded ({}), see config.json.demo for an example".format(args.config, e))
         args.account_name = get_account(args.account_name, config, args.config)['name']
 
-    print("Account name: %s" % args.account_name)
     gather(args)
 
 
@@ -112,9 +110,9 @@ def run_prepare(arguments):
                         required=False, type=str)
     parser.add_argument("--regions", help="Regions to restrict to (ex. us-east-1,us-west-2)",
                         default=None, type=str)
-    parser.add_argument("--vpc-ids", help="VPC ids to restrict to (ex. us-east-1,us-west-2)",
+    parser.add_argument("--vpc-ids", help="VPC ids to restrict to (ex. vpc-1234,vpc-abcd)",
                         default=None, type=str)
-    parser.add_argument("--vpc-names", help="VPC names to restrict to (ex. us-east-1,us-west-2)",
+    parser.add_argument("--vpc-names", help="VPC names to restrict to (ex. prod,dev)",
                         default=None, type=str)
     parser.add_argument("--internal-edges", help="Show all connections (default)",
                         dest='internal_edges', action='store_true')

--- a/cloudmapper.py
+++ b/cloudmapper.py
@@ -49,10 +49,27 @@ def get_account(account_name, config, config_filename):
 def run_gathering(arguments):
     from cloudmapper.gatherer import gather
     parser = argparse.ArgumentParser()
+    parser.add_argument("--config", help="Config file name",
+                        default="config.json", type=str)
     parser.add_argument("--account-name", help="Account to collect from",
-                        required=True, type=str)
+                        required=False, type=str)
+    parser.add_argument("--profile-name", help="AWS profile name",
+                        required=False, type=str)
+    parser.add_argument('--clean', help='Remove any existing data for the account before gathering', action='store_true')
+
     args = parser.parse_args(arguments)
 
+    if not args.account_name:
+        print("No account name defined... getting from config")
+        try:
+            config = json.load(open(args.config))
+        except IOError:
+            exit("ERROR: Unable to load config file \"{}\"".format(args.config))
+        except ValueError as e:
+            exit("ERROR: Config file \"{}\" could not be loaded ({}), see config.json.demo for an example".format(args.config, e))
+        args.account_name = get_account(args.account_name, config, args.config)['name']
+
+    print("Account name: %s" % args.account_name)
     gather(args)
 
 
@@ -95,6 +112,10 @@ def run_prepare(arguments):
                         required=False, type=str)
     parser.add_argument("--regions", help="Regions to restrict to (ex. us-east-1,us-west-2)",
                         default=None, type=str)
+    parser.add_argument("--vpc-ids", help="VPC ids to restrict to (ex. us-east-1,us-west-2)",
+                        default=None, type=str)
+    parser.add_argument("--vpc-names", help="VPC names to restrict to (ex. us-east-1,us-west-2)",
+                        default=None, type=str)
     parser.add_argument("--internal-edges", help="Show all connections (default)",
                         dest='internal_edges', action='store_true')
     parser.add_argument("--no-internal-edges", help="Only show connections to external CIDRs",
@@ -126,6 +147,11 @@ def run_prepare(arguments):
         # Regions are given as 'us-east-1,us-west-2'. Split this by the comma,
         # wrap each with quotes, and add the comma back. This is needed for how we do filtering.
         outputfilter["regions"] = ','.join(['"' + r + '"' for r in args.regions.split(',')])
+    if args.vpc_ids:
+        outputfilter["vpc-ids"] = ','.join(['"' + r + '"' for r in args.vpc_ids.split(',')])
+    if args.vpc_names:
+        outputfilter["vpc-names"] = ','.join(['"' + r + '"' for r in args.vpc_names.split(',')])
+    
     outputfilter["internal_edges"] = args.internal_edges
     outputfilter["read_replicas"] = args.read_replicas
     outputfilter["inter_rds_edges"] = args.inter_rds_edges

--- a/cloudmapper/gatherer.py
+++ b/cloudmapper/gatherer.py
@@ -1,6 +1,7 @@
 import datetime
 import json
-from os import mkdir
+from os import mkdir, path
+from shutil import rmtree
 import boto3
 
 
@@ -11,24 +12,35 @@ def datetime_handler(x):
 
 
 def gather(arguments):
+    account_dir = './{}'.format(arguments.account_name)
+    
+    if arguments.clean and path.exists(account_dir):
+        rmtree(account_dir)
+
     try:
-        mkdir('./{}'.format(arguments.account_name))
+        mkdir(account_dir)
     except OSError:
-        # Already exists
+        # Already exists 
         pass
 
     print("* Getting region names")
-    ec2 = boto3.client('ec2')
+    session_data = {}
+
+    if arguments.profile_name:
+        session_data['profile_name'] = arguments.profile_name
+
+    session = boto3.Session(**session_data)
+    ec2 = session.client('ec2')
 
     region_list = ec2.describe_regions()
-    with open("./{}/describe-regions.json".format(arguments.account_name), 'w+') as f:
+    with open("{}/describe-regions.json".format(account_dir), 'w+') as f:
         f.write(json.dumps(region_list, indent=4, sort_keys=True))
 
     print("* Creating directory for each region name")
 
     for region in region_list['Regions']:
         try:
-            mkdir('./{}/{}'.format(arguments.account_name, region.get('RegionName', 'Unknown')))
+            mkdir('{}/{}'.format(account_dir, region.get('RegionName', 'Unknown')))
         except OSError:
             # Already exists
             pass
@@ -96,5 +108,5 @@ def gather(arguments):
             method_to_call = getattr(handler, runner["Function"])
             data = method_to_call()
             data.pop('ResponseMetadata', None)
-            with open("./{}/{}/{}".format(arguments.account_name, region.get('RegionName', 'Unknown'), runner['FileName']), 'w+') as f:
+            with open("{}/{}/{}".format(account_dir, region.get('RegionName', 'Unknown'), runner['FileName']), 'w+') as f:
                 f.write(json.dumps(data, indent=4, sort_keys=True, default=datetime_handler))

--- a/cloudmapper/gatherer.py
+++ b/cloudmapper/gatherer.py
@@ -20,7 +20,7 @@ def gather(arguments):
     try:
         mkdir(account_dir)
     except OSError:
-        # Already exists 
+        # Already exists
         pass
 
     print("* Getting region names")

--- a/tests/unit/test_prepare.py
+++ b/tests/unit/test_prepare.py
@@ -50,7 +50,7 @@ class TestPrepare(unittest.TestCase):
         json_blob = {u'id': 111111111111, u'name': u'demo'}
         account = Account(None, json_blob)
         region = Region(account, {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1"})
-        assert_equal([{"VpcId": "vpc-12345678", "Tags": [{"Value": "Prod", "Key": "Name"}], "InstanceTenancy": "default", "CidrBlockAssociationSet": [{"AssociationId": "vpc-cidr-assoc-12345678", "CidrBlock": "10.0.0.0/16", "CidrBlockState": {"State": "associated"}}], "State": "available", "DhcpOptionsId": "dopt-12345678", "CidrBlock": "10.0.0.0/16", "IsDefault": True}], get_vpcs(region))
+        assert_equal([{"VpcId": "vpc-12345678", "Tags": [{"Value": "Prod", "Key": "Name"}], "InstanceTenancy": "default", "CidrBlockAssociationSet": [{"AssociationId": "vpc-cidr-assoc-12345678", "CidrBlock": "10.0.0.0/16", "CidrBlockState": {"State": "associated"}}], "State": "available", "DhcpOptionsId": "dopt-12345678", "CidrBlock": "10.0.0.0/16", "IsDefault": True}], get_vpcs(region, {}))
 
     def test_build_data_structure(self):
         # Build the entire demo data set


### PR DESCRIPTION
- Added support for filtering by VPC name or ID when running the `prepare `command.  
- Added support for passing in a profile name when running the `gather` command.
- Removed the need for the account_name when running the `gather`.  It will now pull from the config
- Added a `clean` switch for the `gather` command to remove the account name directory before proceeding.   Not sure if this is needed, as I did it when I was originally adding the vpc flitering during the gather process, but walked that back.  Left it in just in case.
