### PR TITLE
Store and display un-truncated name

### DIFF
--- a/shared/nodes.py
+++ b/shared/nodes.py
@@ -184,8 +184,6 @@ class Node(object):
         response = {"data": {
             "id": self.arn,
             "name": self.name,
-            "fullname": self.fullname,
-            "name_truncated": self.name_truncated,
             "type": self.node_type,
             "local_id": self.local_id,
             "node_data": self.json

--- a/shared/nodes.py
+++ b/shared/nodes.py
@@ -184,6 +184,8 @@ class Node(object):
         response = {"data": {
             "id": self.arn,
             "name": self.name,
+            "fullname": self.fullname,
+            "name_truncated": self.name_truncated,
             "type": self.node_type,
             "local_id": self.local_id,
             "node_data": self.json

--- a/tests/unit/test_nodes.py
+++ b/tests/unit/test_nodes.py
@@ -36,6 +36,11 @@ class TestNodes(unittest.TestCase):
         assert_equal("hello", truncate("hello"))
         assert_equal("0123456789012345678..", truncate("012345678901234567890123456789"))
 
+    def test_get_name(self):
+        assert_equal(('hello', 'hello', False), get_name({'Tags': [{'Key': 'Name', 'Value': 'hello'}], 'ItemId': '12345'}, "ItemId"))
+        assert_equal((truncate('hello-hello-hello-hello-hello-hello-hello-hello-hello-hello'), 'hello-hello-hello-hello-hello-hello-hello-hello-hello-hello', True), get_name({'Tags': [{'Key': 'Name', 'Value': 'hello-hello-hello-hello-hello-hello-hello-hello-hello-hello'}], 'ItemId': '12345'}, "ItemId"))
+        assert_equal(('12345', '12345', False), get_name({'Tags': [], 'ItemId': '12345'}, "ItemId"))
+
     def test_is_public_ip(self):
         assert_true(is_public_ip("1.1.1.1"))
         assert_false(is_public_ip("10.0.0.0"))
@@ -48,7 +53,7 @@ class TestNodes(unittest.TestCase):
         assert_equal("account", account.node_type)
         assert_equal("arn:aws:::111111111111:", account.arn)
         assert_false(account.isLeaf)
-        assert_equal("prod", get_name(json_blob, "name"))
+        assert_equal("prod", get_name(json_blob, "name")[0])
         assert_false(account.has_leaves)
         assert_equal([], account.leaves)
         assert_equal({'data': {'node_data': {u'id': 111111111111, u'name': u'prod'}, 'local_id': 111111111111, 'type': 'account', 'id': 'arn:aws:::111111111111:', 'name': u'prod'}}, account.cytoscape_data())

--- a/tests/unit/test_nodes.py
+++ b/tests/unit/test_nodes.py
@@ -56,4 +56,4 @@ class TestNodes(unittest.TestCase):
         assert_equal("prod", get_name(json_blob, "name")[0])
         assert_false(account.has_leaves)
         assert_equal([], account.leaves)
-        assert_equal({'data': {'node_data': {u'id': 111111111111, u'name': u'prod'}, 'local_id': 111111111111, 'type': 'account', 'id': 'arn:aws:::111111111111:', 'name': u'prod'}}, account.cytoscape_data())
+        assert_equal({'data': {'node_data': {u'id': 111111111111, u'name': u'prod'}, 'local_id': 111111111111, 'type': 'account', 'id': 'arn:aws:::111111111111:', 'name': u'prod', u'fullname': u'prod', u'name_truncated': False}}, account.cytoscape_data())

--- a/web/js/nodeInfo.js
+++ b/web/js/nodeInfo.js
@@ -62,7 +62,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
             } else {
                 summary.append('<span class="label">Type:</span><span> '+n.data().type+'</span><br>');
                 summary.append('<span class="label">ID:</span><span> '+n.data().local_id+'</span><br>');
-                summary.append('<span class="label">Name:</span><span> '+n.data().name+'</span><br>');
+                if (n.data().name_truncated){
+                    summary.append('<span class="label">Name:</span><span title="'+n.data().fullname+'"'+'> '+n.data().name+'</span><br>');
+                } else {
+                    summary.append('<span class="label">Name:</span><span> '+n.data().name+'</span><br>');
+                }
             }
             
             var details = $('#Details');


### PR DESCRIPTION
I've found it quite awkward with the name always being truncated, as I have quite a long prefix on the names in my account. The ID does not always tie up with the name, meaning that I can't necessarily tell what is what.

This PR does the following:

* Store un-truncated name in `data.json`
* Store whether the name has been truncated or not
* Display this as a tooltip via the 'title' property of the name label
