### PR TITLE
added ADFS SAML to principals for WoT

### DIFF
--- a/commands/wot.py
+++ b/commands/wot.py
@@ -171,6 +171,9 @@ def get_iam_trusts(account, nodes, connections, connections_to_get):
                 if "saml-provider/okta" in principal['Federated'].lower():
                     node = Account(json_blob={'id':'okta', 'name':'okta', 'type':'Okta'})
                     assume_role_nodes.add(node)
+                elif "saml-provider/adfs" in principal['Federated'].lower():
+                    node = Account(json_blob={'id':'adfs', 'name':'adfs', 'type':'ADFS'})
+                    assume_role_nodes.add(node)
                 elif principal['Federated'] == 'cognito-identity.amazonaws.com':
                     # TODO: Should show this somehow
                     continue


### PR DESCRIPTION
When using ADFS running the ./cloudmapper.py would not work due to the SAML provider not being a known principal for IAM trusts. This fix resolves the issue by adding 'saml-provider/adfs' to if/elif statements.