### PR TITLE
Optionally collapse ASGS

### DIFF
--- a/commands/prepare.py
+++ b/commands/prepare.py
@@ -235,7 +235,9 @@ def build_data_structure(account_data, config, outputfilter):
 
                     # Get EC2's
                     for ec2_json in get_ec2s(subnet):
-                        ec2 = Ec2(subnet, ec2_json, outputfilter["collapse_by_tag"])
+                        ec2 = Ec2(subnet, ec2_json,
+                                  outputfilter["collapse_by_tag"],
+                                  outputfilter["collapse_asgs"])
                         subnet.addChild(ec2)
 
                     # Get RDS's
@@ -375,6 +377,8 @@ def run(arguments):
                         dest='azs', action='store_false')
     parser.add_argument("--collapse-by-tag", help="Collapse nodes with the same tag to a single node",
                         dest='collapse_by_tag', default=None, type=str)
+    parser.add_argument("--collapse-asgs", help="Only show the AutoScalingGroup instead of all contained instances.",
+                        dest='collapse_asgs', action='store_true')
 
     parser.set_defaults(internal_edges=True)
     parser.set_defaults(inter_rds_edges=False)
@@ -398,6 +402,7 @@ def run(arguments):
     outputfilter["inter_rds_edges"] = args.inter_rds_edges
     outputfilter["azs"] = args.azs
     outputfilter["collapse_by_tag"] = args.collapse_by_tag
+    outputfilter["collapse_asgs"] = args.collapse_asgs
 
     # Read accounts file
     try:

--- a/docs/network_visualizations.md
+++ b/docs/network_visualizations.md
@@ -15,6 +15,7 @@ The most useful filtering options:
 * `--regions`: Restrict the diagram to a set regions, ex. `us-east-1,us-east-2`
 * `--vpc-ids` and `--vpc-names`: Restrict the diagram to a set of VPCs.
 * `--collapse-by-tag`: This is very useful to provide a tag name, and all nodes with that tag will be reduced to a single displayed node.
+* `--collapse-asgs`: Collapses multiple EC2 instances into their and AutoScalingGroup. When the ASG spreads accross multiple Availability Zones, only one will be displayed.
 
 The other filtering options are:
 * `--internal-edges` (default) and `--no-internal-edges`: When you only care about showing what is publicly accessible, use `--no-internal-edges`.

--- a/docs/network_visualizations.md
+++ b/docs/network_visualizations.md
@@ -15,7 +15,7 @@ The most useful filtering options:
 * `--regions`: Restrict the diagram to a set regions, ex. `us-east-1,us-east-2`
 * `--vpc-ids` and `--vpc-names`: Restrict the diagram to a set of VPCs.
 * `--collapse-by-tag`: This is very useful to provide a tag name, and all nodes with that tag will be reduced to a single displayed node.
-* `--collapse-asgs`: Collapses multiple EC2 instances into their and AutoScalingGroup. When the ASG spreads accross multiple Availability Zones, only one will be displayed.
+* `--collapse-asgs`: Collapses multiple EC2 instances into their AutoScalingGroup. When the ASG spreads accross multiple Availability Zones, only one will be displayed.
 
 The other filtering options are:
 * `--internal-edges` (default) and `--no-internal-edges`: When you only care about showing what is publicly accessible, use `--no-internal-edges`.
@@ -71,4 +71,3 @@ When you first start, the initial layout is never ideal.  We use what is believe
 
 Here is the layout you'll likely see initially when you view the demo:
 ![Initial layout](docs/images/initial_layout.png "Initial layout")
-

--- a/shared/nodes.py
+++ b/shared/nodes.py
@@ -286,7 +286,7 @@ class Ec2(Leaf):
             collapse_by_tag_value = pyjq.all('.Tags[] | select(.Key == "{}") | .Value'.format(collapse_by_tag), json_blob)
         if autoscaling_name != []:
             self._type = "autoscaling"
-            self._local_id = autoscaling_name[0]
+            self._local_id = autoscaling_name[0] + parent.local_id
         elif collapse_by_tag_value != []:
             self._type = "grouped_ec2"
             self._local_id = "grouped_ec2_{}".format(collapse_by_tag_value[0])

--- a/shared/nodes.py
+++ b/shared/nodes.py
@@ -279,14 +279,16 @@ class Ec2(Leaf):
     def security_groups(self):
         return pyjq.all('.SecurityGroups[].GroupId', self._json_blob)
 
-    def __init__(self, parent, json_blob, collapse_by_tag=None):
-        autoscaling_name = pyjq.all('.Tags[] | select(.Key == "aws:autoscaling:groupName") | .Value', json_blob)
+    def __init__(self, parent, json_blob, collapse_by_tag=None, collapse_asgs=False):
+        autoscaling_name = []
+        if collapse_asgs:
+            autoscaling_name = pyjq.all('.Tags[] | select(.Key == "aws:autoscaling:groupName") | .Value', json_blob)
         collapse_by_tag_value = []
         if collapse_by_tag:
             collapse_by_tag_value = pyjq.all('.Tags[] | select(.Key == "{}") | .Value'.format(collapse_by_tag), json_blob)
         if autoscaling_name != []:
             self._type = "autoscaling"
-            self._local_id = autoscaling_name[0] + parent.local_id
+            self._local_id = autoscaling_name[0]
         elif collapse_by_tag_value != []:
             self._type = "grouped_ec2"
             self._local_id = "grouped_ec2_{}".format(collapse_by_tag_value[0])

--- a/tests/unit/test_prepare.py
+++ b/tests/unit/test_prepare.py
@@ -56,6 +56,7 @@ class TestPrepare(unittest.TestCase):
         outputfilter["inter_rds_edges"] = True
         outputfilter["azs"] = False
         outputfilter["collapse_by_tag"] = False
+        outputfilter["collapse_asgs"] = False
 
         config = {"accounts": [{"id": 123456789012, "name": "demo"}], "cidrs": {"1.1.1.1/32": {"name": "SF Office"}, "2.2.2.2/28": {"name": "NY Office"}}}
 


### PR DESCRIPTION
Multiple instances in the same subnet will collapse because of the same id, but when in different subnets they'll get a new id and get rendered.

Now this is taking advantage of the fact that crytoscape only renders one node per ID, there must be a more pragmatic approach to not outputting collapsed nodes at all. But it seems like a fine quick dirty fix.

Is this viable?

**Update**: Ended up going with your first suggestion with `--collapse-asgs`.