### PR TITLE
Docs: Fix image URL in Network visualizations 

### DIFF
--- a/docs/network_visualizations.md
+++ b/docs/network_visualizations.md
@@ -70,4 +70,4 @@ Commands
 When you first start, the initial layout is never ideal.  We use what is believed to be the best layout algorithm for compound node diagrams, [CoSE](https://github.com/cytoscape/cytoscape.js-cose-bilkent), but this will still require manual editing by moving nodes around.
 
 Here is the layout you'll likely see initially when you view the demo:
-![Initial layout](docs/images/initial_layout.png "Initial layout")
+![Initial layout](/docs/images/initial_layout.png "Initial layout")


### PR DESCRIPTION
The last image, "initial layout", in the "Network visualizations" page is broken because a slash ("/") is missing, see: https://github.com/duo-labs/cloudmapper/blob/master/docs/network_visualizations.md

I fixed the URL so that it links to the image as seen here: https://github.com/synoa/cloudmapper/blob/fix/broken-image-docs/docs/network_visualizations.md