### PR TITLE
add travis badge to the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 CloudMapper
 ========
+[![Build Status](https://travis-ci.org/duo-labs/cloudmapper.svg?branch=master)](https://travis-ci.org/duo-labs/cloudmapper)
+
 CloudMapper helps you analyze your Amazon Web Services (AWS) environments.  The original purpose was to generate network diagrams and display them in your browser.  It now contains much more functionality.
 
 *Demo: https://duo-labs.github.io/cloudmapper/*


### PR DESCRIPTION
I'm pretty sure in my last PR the Travis build was working. Now it was broken by accepting recent PRs. I think it is best to add the badge on the main README to make sure that the travis build is always passing :)