### PR TITLE
add AttributeNames parameter to sqs get-queue-attributes command

### DIFF
--- a/collect_commands.yaml
+++ b/collect_commands.yaml
@@ -84,6 +84,8 @@
   Parameters:
   - Name: QueueUrl
     Value: sqs-list-queues.json|.QueueUrls[]?
+  - Name: AttributeNames
+    Value: [All]
 - Service: sns
   Request: list-topics
 - Service: sns


### PR DESCRIPTION
One possible solution for issue #209.   This sets the parameter to default as 'All', retrieving all attribute data about the queue.

Contents of file generated for queue url:
```{
    "Attributes": {
        "ApproximateNumberOfMessages": "0",
        "ApproximateNumberOfMessagesDelayed": "0",
        "ApproximateNumberOfMessagesNotVisible": "0",
        "CreatedTimestamp": "1533944584",
        "DelaySeconds": "0",
        "LastModifiedTimestamp": "1534547074",
        "MaximumMessageSize": "262144",
        "MessageRetentionPeriod": "345600",
        "QueueArn": "arn:aws:sqs:::",
        "ReceiveMessageWaitTimeSeconds": "0",
        "VisibilityTimeout": "30"
    }
}
```