### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ git clone git@github.com:duo-labs/cloudmapper.git
 # sudo yum install autoconf automake libtool python3-devel.x86_64 python3-tkinter jq awscli
 # (Debian, Ubuntu etc.):
 # You may additionally need "build-essential"
-sudo apt-get install autoconf automake libtool python3-dev python3-tk jq awscli
+sudo apt-get install autoconf automake libtool python3.7-dev python3-tk jq awscli
 cd cloudmapper/
 pipenv install --skip-lock
 pipenv shell


### PR DESCRIPTION
For the installation of pyjq via pip, the 3.7 version of the python dev package is required.

See also https://github.com/doloopwhile/pyjq/issues/16