### PR TITLE
DOC: Add pipenv installation for macOS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ On macOS:
 # clone the repo
 git clone git@github.com:duo-labs/cloudmapper.git
 # Install pre-reqs for pyjq
-brew install autoconf automake libtool jq awscli python3
+brew install autoconf automake libtool jq awscli python3 pipenv
 cd cloudmapper/
 pipenv install --skip-lock
 pipenv shell


### PR DESCRIPTION
Hi,

for macOS X, we need to install pipenv via brew.

Maybe it's also needed for linux ?

Thanks.