### PR TITLE
Fix NameError that occurs when running audit command

### DIFF
--- a/commands/audit.py
+++ b/commands/audit.py
@@ -447,14 +447,15 @@ def audit_sqs(region):
         return
 
     for queue in json_blob.get('QueueUrls', []):
+        queue_name = queue.split("/")[-1]
         # Check policy
-        attributes = get_parameter_file(region, 'sqs', 'get-queue-attributes', queue)
-        if attributes is None:
+        queue_attributes = get_parameter_file(region, 'sqs', 'get-queue-attributes', queue)
+        if queue_attributes is None:
             # No policy
             continue
 
         # Find the entity we need
-        attributes = attributes['Attributes']
+        attributes = queue_attributes['Attributes']
         if 'Policy' in attributes:
             policy_string = attributes['Policy']
         else:
@@ -465,7 +466,7 @@ def audit_sqs(region):
         policy = json.loads(policy_string)
         policy = Policy(policy)
         if policy.is_internet_accessible():
-            print('- Internet accessible SQS {}: {}'.format(name, policy_string))
+            print('- Internet accessible SQS {}: {}'.format(queue_name, policy_string))
 
 
 def audit_sns(region):


### PR DESCRIPTION
👋Thanks for making this OSS ❤️ 

I have only tried running this on the collected data from one AWS account. I ran into an issue so sharing the fix in case it affects more than just me.

### What does this change?

#### 👉Fix NameError during audit command

running `python cloudmapper.py audit --accounts exampleAccount` ran into this error:

```sh
Exception in awsAccount in us-east-1
Traceback (most recent call last):
  File "/somepath/cloudmapper/commands/audit.py", line 551, in audit
    audit_sqs(region)
  File "/somepath/cloudmapper/commands/audit.py", line 468, in audit_sqs
    print('- Internet accessible SQS {}: {}'.format(name, policy_string))
NameError: name 'name' is not defined
```

This was occurring due to `name` being referenced on line 468 but not defined.

Having the SQS name appear in the output is still desirable so this PR extracts it from the queue url so that it can be used in the print statement. 

#### 👉Renames variable to prevent shadowing of `attributes`.

Lines 451 and 457 both assign a value to `attributes` and the variable shadowing confused me for a second. 😖

Removing the shadowing since they are in the same scope and not sure if this was intentional?

### What is the value of this?

Users with Internet accessible SQS will no longer experience a NameError 

Making these edits locally has fixed the audit, and allowed me to get the audit report  🙌  🤘

