### PR TITLE
Read from relative path to allow hosting with subdir's

### DIFF
--- a/web/js/cloudmap.js
+++ b/web/js/cloudmap.js
@@ -37,7 +37,7 @@ $(window).on('load', function(){
     
     $.when(
         $.getJSON("./data.json"),
-        $.getJSON("/style.json")
+        $.getJSON("./style.json")
     ).done(function(datafile, stylefile) {
         loadCytoscape({
             wheelSensitivity: 0.1,


### PR DESCRIPTION
Load `style.json` by relative path to enable to host flexible structure.