### PR TITLE
Enable to filter ec2 instances by tags

### DIFF
--- a/tests/unit/test_prepare.py
+++ b/tests/unit/test_prepare.py
@@ -28,8 +28,8 @@ from mock import patch
 from nose.tools import assert_equal, assert_true, assert_false
 import pyjq
 
-from commands.prepare import is_external_cidr, get_regions, get_vpcs, build_data_structure
-from shared.nodes import Account, Region
+from commands.prepare import is_external_cidr, get_ec2s, get_vpcs, build_data_structure
+from shared.nodes import Account, Region, Subnet, Vpc
 
 
 class TestPrepare(unittest.TestCase):
@@ -45,6 +45,19 @@ class TestPrepare(unittest.TestCase):
         account = Account(None, json_blob)
         region = Region(account, {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1"})
         assert_equal([{"VpcId": "vpc-12345678", "Tags": [{"Value": "Prod", "Key": "Name"}], "InstanceTenancy": "default", "CidrBlockAssociationSet": [{"AssociationId": "vpc-cidr-assoc-12345678", "CidrBlock": "10.0.0.0/16", "CidrBlockState": {"State": "associated"}}], "State": "available", "DhcpOptionsId": "dopt-12345678", "CidrBlock": "10.0.0.0/16", "IsDefault": True}], get_vpcs(region, {}))
+
+    def test_get_ec2s(self):
+        # This actually uses the demo data files provided
+        json_blob = {u'id': 111111111111, u'name': u'demo'}
+        account = Account(None, json_blob)
+        region = Region(account, {"Endpoint": "ec2.us-east-1.amazonaws.com", "RegionName": "us-east-1"})
+        vpc = Vpc(region, get_vpcs(region, {})[0])
+        subnet = Subnet(vpc, {"SubnetId": "subnet-00000001", "Tags": [{"Value": "Public a1", "Key": "Name"}]})
+
+        instances_passed = get_ec2s(subnet, {"ec2_tags": "Name=Bastion"})
+        assert_equal(len(instances_passed), 1)
+        instances_filtered = get_ec2s(subnet, {"ec2_tags": "NonexistentTagName=NonexistentTagValue"})
+        assert_equal(len(instances_filtered), 0)
 
     def test_build_data_structure(self):
         # Build the entire demo data set


### PR DESCRIPTION
I want more flexible filters to display only important components, tag-based filter is one of the filter.