### PR TITLE
Remove unneeded extra policy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,38 +92,6 @@ You must have the following privileges (these grant various read access of metad
 - `arn:aws:iam::aws:policy/SecurityAudit`
 - `arn:aws:iam::aws:policy/job-function/ViewOnlyAccess`
 
-And also:
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "elasticfilesystem:DescribeMountTargetSecurityGroups",
-                "elasticfilesystem:DescribeMountTargets",
-                "fms:ListComplianceStatus",
-                "fms:ListPolicies",
-                "iot:GetPolicy",
-                "iot:GetPolicyVersion",
-                "lambda:GetFunctionConfiguration",
-                "lambda:GetLayerVersionPolicy",
-                "sso:DescribePermissionsPolicies",
-                "sso:ListApplicationInstanceCertificates",
-                "sso:ListApplicationInstances",
-                "sso:ListApplicationTemplates",
-                "sso:ListApplications",
-                "sso:ListDirectoryAssociations",
-                "sso:ListPermissionSets",
-                "sso:ListProfileAssociations",
-                "sso:ListProfiles"
-            ],
-            "Resource": "*",
-            "Effect": "Allow"
-        }
-    ]
-}
-```
-
 ### Collect the data
 
 Collecting the data is done as follows:


### PR DESCRIPTION
The SecurityAudit policy now has everything. See https://github.com/SummitRoute/aws_managed_policies/commit/df4502d37e7126d9e5fe8add38cd9ab8aed8f3eb#diff-831d569bb19b182bb12f48b976d5c98fR59