### PR TITLE
Fix node methods

### DIFF
--- a/shared/nodes.py
+++ b/shared/nodes.py
@@ -593,6 +593,7 @@ class Ecs(Leaf):
         for detail in pyjq.all('.attachments[].details[]', self._json_blob):
             if detail['name'] == 'subnetId':
                 return [detail['value']]
+        return []
 
     @property
     def tags(self):

--- a/shared/nodes.py
+++ b/shared/nodes.py
@@ -350,7 +350,10 @@ class Elb(Leaf):
         tags = get_parameter_file(self.region, 'elb', 'describe-tags', self._json_blob['LoadBalancerName']) 
         if tags is None:
             return []
-        return tags['TagDescriptions']['Tags']
+        descriptions = tags['TagDescriptions']
+        if descriptions is None or len(descriptions) == 0:
+            return []
+        return descriptions[0]['Tags']
 
     def set_subnet(self, subnet):
         self._subnet = subnet
@@ -401,7 +404,10 @@ class Elbv2(Leaf):
         tags = get_parameter_file(self.region, 'elbv2', 'describe-tags', self._json_blob['LoadBalancerName']) 
         if tags is None:
             return []
-        return tags['TagDescriptions']['Tags']
+        descriptions = tags['TagDescriptions']
+        if descriptions is None or len(descriptions) == 0:
+            return []
+        return descriptions[0]['Tags']
 
     def set_subnet(self, subnet):
         self._subnet = subnet


### PR DESCRIPTION
- Fix indexes because TagDescriptions field is list
- Avoid to return None when mismatching
  - The None causes error in `add_node_to_subnets()`