### PR TITLE
Problems when generating report

### DIFF
--- a/shared/audit.py
+++ b/shared/audit.py
@@ -625,8 +625,8 @@ def audit_sg(findings, region):
             if cidr == '0.0.0.0/0':
                 continue
 
-            cidrs[cidr] = cidrs.get(cidr, set())
-            cidrs[cidr].add(sg['GroupId'])
+            cidrs[cidr] = cidrs.get(cidr, list())
+            cidrs[cidr].append(sg['GroupId'])
 
         for ip_permissions in sg['IpPermissions']:
             cidrs_seen = set()

--- a/shared/public.py
+++ b/shared/public.py
@@ -109,7 +109,7 @@ def get_public_nodes(account, config, use_cache=False):
             target['type'] = 'ec2'
             dns_name = target_node['node_data'].get('PublicDnsName', '')
             target['hostname'] = target_node['node_data'].get('PublicIpAddress', dns_name)
-            target['tags'] = target_node['node_data']['Tags']
+            target['tags'] = target_node['node_data'].get('Tags', [])
         elif target_node['type'] == 'ecs':
             target['type'] = 'ecs'
             target['hostname'] = ''


### PR DESCRIPTION
Found 2 problems when generating reports:

1. Some EC2 instances might not have Tags
2. Security groups are declared as set and cannot be serialized to JSON