### PR TITLE
Update README.md (ssh -> https in git clone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ On macOS:
 
 ```
 # clone the repo
-git clone git@github.com:duo-labs/cloudmapper.git
+git clone https://github.com/duo-labs/cloudmapper.git
 # Install pre-reqs for pyjq
 brew install autoconf automake libtool jq awscli python3 pipenv
 cd cloudmapper/
@@ -35,7 +35,7 @@ pipenv shell
 On Linux:
 ```
 # clone the repo
-git clone git@github.com:duo-labs/cloudmapper.git
+git clone https://github.com/duo-labs/cloudmapper.git
 # (AWS Linux, Centos, Fedora, RedHat etc.):
 # sudo yum install autoconf automake libtool python3-devel.x86_64 python3-tkinter python-pip jq awscli
 # (Debian, Ubuntu etc.):


### PR DESCRIPTION
Changed `git clone` instruction in examples to use `https` instead of `ssh`.

Reason:

```
$ git clone git@github.com:duo-labs/cloudmapper.git
Cloning into 'cloudmapper'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.


$ git clone https://github.com/duo-labs/cloudmapper.git
Cloning into 'cloudmapper'...
remote: Enumerating objects: 87, done.
remote: Counting objects: 100% (87/87), done.
remote: Compressing objects: 100% (57/57), done.
remote: Total 2716 (delta 36), reused 62 (delta 28), pack-reused 2629
Receiving objects: 100% (2716/2716), 7.31 MiB | 2.56 MiB/s, done.
Resolving deltas: 100% (1409/1409), done.
```