### PR TITLE
Slack output

### DIFF
--- a/commands/audit.py
+++ b/commands/audit.py
@@ -1,5 +1,6 @@
 import argparse
 import yaml
+import json
 
 from shared.common import parse_arguments
 from shared.audit import audit, load_audit_config, finding_is_filtered
@@ -21,7 +22,9 @@ def audit_command(accounts, config, args):
             continue
 
         if args.json:
-            print(finding)
+            finding = json.loads(str(finding))
+            finding['finding_type_metadata']= conf
+            print(json.dumps(finding))
         else:
             print(
                 "{} - {} ({}) - {}: {}".format(

--- a/commands/audit.py
+++ b/commands/audit.py
@@ -25,6 +25,19 @@ def audit_command(accounts, config, args):
             finding = json.loads(str(finding))
             finding['finding_type_metadata']= conf
             print(json.dumps(finding))
+        elif args.markdown:
+            print(
+                "*Audit Finding: [{}] - {}*\\nAccount: {} ({}) - {}\\nDescription: {}\\nResource: `{}`\\nDetails:```{}```".format(
+                    conf["severity"].upper(),
+                    conf["title"],
+                    finding.region.account.name,
+                    finding.region.account.local_id,
+                    finding.region.name,
+                    conf["description"],
+                    finding.resource_id,
+                    str(finding.resource_details).replace('\n', '\\n')
+                )
+            )
         else:
             print(
                 "{} - {} ({}) - {}: {}".format(
@@ -42,6 +55,12 @@ def run(arguments):
     parser.add_argument(
         "--json",
         help="Print the json of the issues",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "--markdown",
+        help="Print issue as markdown (for Slack)",
         default=False,
         action="store_true",
     )

--- a/utils/toslack.py
+++ b/utils/toslack.py
@@ -1,0 +1,24 @@
+import json
+import requests
+import sys
+import os
+
+# Usage: Set the environment variable SLACK_WEBHOOK to https://hooks.slack.com/services/XXXX/YYYYY
+
+webhook_url = os.environ['SLACK_WEBHOOK']
+
+for line in sys.stdin:
+    line.rstrip()
+    line = line.replace('\\n', '\n')
+    #print(line)
+
+    slack_data = {'text': line}
+
+    response = requests.post(
+        webhook_url, data=json.dumps(slack_data),
+        headers={'Content-Type': 'application/json'}
+    )
+    if response.status_code != 200:
+        raise ValueError(
+            'Request to slack returned an error %s, the response is:\n%s'
+            % (response.status_code, response.text))


### PR DESCRIPTION
Flag to write the audit output as markdown so it can be piped to Slack, and a simple utility to send that text to Slack. Example screenshots below.

<img width="993" alt="Screen Shot 2019-07-26 at 11 39 33 AM" src="https://user-images.githubusercontent.com/1979334/61972128-0a0f9e00-af9e-11e9-9cb5-9c8258f446ba.png">
<img width="945" alt="Screen Shot 2019-07-26 at 11 40 09 AM" src="https://user-images.githubusercontent.com/1979334/61972130-0aa83480-af9e-11e9-861a-dc62b4e1e45e.png">
