### PR TITLE
Filtering findings for generating reports with multiple accounts

### DIFF
--- a/commands/report.py
+++ b/commands/report.py
@@ -314,7 +314,8 @@ def report(accounts, config, args):
         for severity in SEVERITIES:
             findings_severity_by_account[account["name"]][severity["name"]] = {}
 
-        for finding in findings:
+        # Filtering the list of findings down to the ones specific to the current account.
+        for finding in [f for f in findings if f.account_name == account["name"]]:
             conf = audit_config[finding.issue_id]
             if finding_is_filtered(finding, conf):
                 continue


### PR DESCRIPTION
While using this tool to generate a combined report for a number of accounts I would get this error (while using `all` and listing accounts manually):
```
jshodd > cloudmapper > python cloudmapper.py report --accounts product,test
* Getting resource counts
  - product
  - test
* Getting IAM data
  - product
  - test
* Getting public resource data
  - product
  - test
* Auditing accounts
Traceback (most recent call last):
  File "cloudmapper.py", line 72, in <module>
    main()
  File "cloudmapper.py", line 66, in main
    commands[command].run(arguments)
  File "/Users/jshodd/opt/tools/cloudmapper/commands/report.py", line 454, in run
    report(accounts, config, args)
  File "/Users/jshodd/opt/tools/cloudmapper/commands/report.py", line 322, in report
    count = findings_severity_by_account[finding.account_name][
KeyError: 'test'
``` 

Looking at the code It seems that the lsit `findings` contains a list of findings for _all_ accounts being reported on, but we are looping over that list for each account and adding findings to `findings_severity_by_account` with the key being the account name on the finding. The issue there is that the account name key is only being added as the loop iterates over each account. So on the first account that gets iterated, it creates a key in `findings_severity_by_account` with it's account name and then loops over the findings. The findings loop adds findings to that dict using `finding.acount_name` which works fine for the first x number of findings, because they are all for the same first account, but then that loop encounters a finding where `finding.account_name` is equal to the next account and tries to do the following:

```
            count = findings_severity_by_account[finding.account_name][
                conf["severity"]
            ].get(finding.issue_id, 0)
```
but at this time, the second account has not been looped over yet, so `findings_severity_by_account[finding.account_name]` doesn't exist yet. My change uses a list comprehension to filter down the list `findings` so that we are only looping over a list of findings for that specific account so that this key error does not occur. After this change the operation works as expected:

```
 jshodd > cloudmapper > python cloudmapper.py report --accounts product,test
* Getting resource counts
  - product
  - test
* Getting IAM data
  - product
  - test
* Getting public resource data
  - product
  - test
* Auditing accounts
Report written to web/account-data/report.html
```
