### PR TITLE
Add Threat Stack vendor account

### DIFF
--- a/vendor_accounts.yaml
+++ b/vendor_accounts.yaml
@@ -155,3 +155,6 @@
 - name: 'Databricks'
   source: 'https://docs.databricks.com/administration-guide/account-settings/aws-accounts.html'
   accounts: ['414351767826']
+- name: 'Threat Stack'
+  source: 'https://threatstack.zendesk.com/hc/en-us/articles/206006626-AWS-EC2-Integration'
+  accounts: ['896126563706']


### PR DESCRIPTION
Adds the Threat Stack vendor account.

Icon is already present:

https://github.com/duo-labs/cloudmapper/blob/e99df1199672e428dd7a80cddc1f57699ac24b87/web/style.json#L586-L596