### PR TITLE
Check for node._parent before iterating

### DIFF
--- a/commands/prepare.py
+++ b/commands/prepare.py
@@ -326,7 +326,7 @@ def add_node_to_subnets(region, node, nodes):
 
     # Add a new node (potentially the same one) back to the dictionary
     for vpc in region.children:
-        if len(node.subnets) == 0 and vpc.local_id == node._parent.local_id:
+        if len(node.subnets) == 0 and node._parent and vpc.local_id == node._parent.local_id:
             # VPC Gateway Endpoints (S3 and DynamoDB) reside in a VPC, not a subnet
             # So set the relationship between the VPC and the node
             nodes[node.arn] = node


### PR DESCRIPTION
VpcEndpoint has _parent set to None when the endpoint is not in the vpc filter list.  Skip these objects.

Fixes #625 