### PR TITLE
Show inline policies correctly in iam_report

### DIFF
--- a/commands/iam_report.py
+++ b/commands/iam_report.py
@@ -552,7 +552,7 @@ def iam_report(accounts, config, args):
         policies.extend(stats["auth"].get("RolePolicyList", []))
         p["inline_policies"] = []
         for policy in policies:
-            p["managed_policies"].append(
+            p["inline_policies"].append(
                 {
                     "name": policy["PolicyName"],
                     "document": json.dumps(policy["PolicyDocument"], indent=4),


### PR DESCRIPTION
Started investigating the IAM report, and saw inline policies were not shown correctly. Apparently - they are added to the wrong list, the `managed_policies` list.
This fixes that, and they are now shown nicely