### PR TITLE
add logger to set policyuniverse CRITICAL only fixes #672

### DIFF
--- a/commands/iam_report.py
+++ b/commands/iam_report.py
@@ -8,12 +8,15 @@ from six import add_metaclass
 from jinja2 import Template
 from enum import Enum
 
+from logging import CRITICAL
+from logging import getLogger
 from policyuniverse.policy import Policy
 from shared.common import parse_arguments, get_regions
 from shared.query import query_aws, get_parameter_file
 from shared.nodes import Account, Region
 
 __description__ = "Create IAM report"
+getLogger("policyuniverse").setLevel(CRITICAL)
 
 
 class OutputFormat(Enum):

--- a/shared/audit.py
+++ b/shared/audit.py
@@ -8,6 +8,8 @@ import pkgutil
 import importlib
 import inspect
 
+from logging import CRITICAL
+from logging import getLogger
 from policyuniverse.policy import Policy
 
 from netaddr import IPNetwork
@@ -26,6 +28,7 @@ from shared.iam_audit import find_admins_in_account
 
 # Global
 custom_filter = None
+getLogger("policyuniverse").setLevel(CRITICAL)
 
 
 class Findings(object):

--- a/shared/iam_audit.py
+++ b/shared/iam_audit.py
@@ -5,6 +5,8 @@ import traceback
 import re
 import os.path
 
+from logging import CRITICAL
+from logging import getLogger
 from policyuniverse.policy import Policy
 from parliament import analyze_policy_string
 
@@ -13,7 +15,7 @@ from shared.common import Finding, make_list, get_us_east_1, get_current_policy_
 from shared.query import query_aws, get_parameter_file
 from shared.nodes import Account, Region
 
-
+getLogger("policyuniverse").setLevel(CRITICAL)
 KNOWN_BAD_POLICIES = {
     "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM": "Use AmazonSSMManagedInstanceCore instead and add privs as needed",
     "arn:aws:iam::aws:policy/service-role/AmazonMachineLearningRoleforRedshiftDataSource": "Use AmazonMachineLearningRoleforRedshiftDataSourceV2 instead",


### PR DESCRIPTION
This fixes issue #672 by suppressing the Netflix PolicyUniverse logger where it exists in the project.  Sets `CRITICAL` instead of `WARNING` which is the default.

Tested against my own account data producing the artifacts.