### PR TITLE
Describe ECS tasks in chunks

### DIFF
--- a/commands/prepare.py
+++ b/commands/prepare.py
@@ -135,16 +135,16 @@ def get_ecs_tasks(region):
     clusters = query_aws(region.account, "ecs-list-clusters", region.region)
     for clusterArn in clusters.get("clusterArns", []):
         tasks_json = get_parameter_file(region, "ecs", "list-tasks", clusterArn)
-        for taskArn in tasks_json["taskArns"]:
+        for i in range(0, len(tasks_json["taskArns"]) // 100):
             task_path = "account-data/{}/{}/{}/{}/{}".format(
                 region.account.name,
                 region.region.name,
                 "ecs-describe-tasks",
                 urllib.parse.quote_plus(clusterArn),
-                urllib.parse.quote_plus(taskArn),
+                urllib.parse.quote_plus(f"describe_tasks_{i}")
             )
-            task = json.load(open(task_path))
-            tasks.append(task["tasks"][0])
+            cluster_tasks = json.load(open(task_path))
+            tasks += cluster_tasks["tasks"]
     return tasks
 
 


### PR DESCRIPTION
Hey!

We started (ab)using ECS tasks, and we reached the ECS describe-stack rate limits. To resolve, I used chunking (there's a limit of 100 tasks per API call) 