### PR TITLE
Region filter

### DIFF
--- a/cloudmapper.py
+++ b/cloudmapper.py
@@ -61,7 +61,7 @@ def main():
 
     command = sys.argv[1]
     arguments = sys.argv[2:]
-
+    
     if command in commands:
         commands[command].run(arguments)
     else:

--- a/commands/collect.py
+++ b/commands/collect.py
@@ -203,6 +203,10 @@ def collect(arguments):
 
     summary = []
 
+    regions_filter = None
+    if len(arguments.regions_filter) > 0:
+        regions_filter = arguments.regions_filter.split(",")
+
     if arguments.clean and os.path.exists("account-data/{}".format(account_dir)):
         rmtree("account-data/{}".format(account_dir))
 
@@ -269,6 +273,11 @@ def collect(arguments):
     print("* Getting region names", flush=True)
     ec2 = session.client("ec2")
     region_list = ec2.describe_regions()
+
+    if regions_filter is not None:
+        filtered_regions = [r for r in region_list["Regions"] if r["RegionName"] in regions_filter]
+        region_list["Regions"] = filtered_regions
+
     with open("account-data/{}/describe-regions.json".format(account_dir), "w+") as f:
         f.write(json.dumps(region_list, indent=4, sort_keys=True))
 
@@ -516,6 +525,14 @@ def run(arguments):
         type=int,
         dest="max_attempts",
         default=4
+    )
+    parser.add_argument(
+        "--regions",
+        help="Filter and query AWS only for the given regions (CSV)",
+        required=False,
+        type=str,
+        dest="regions_filter",
+        default=""
     )
 
     args = parser.parse_args(arguments)

--- a/commands/collect.py
+++ b/commands/collect.py
@@ -203,10 +203,6 @@ def collect(arguments):
 
     summary = []
 
-    regions_filter = None
-    if len(arguments.regions_filter) > 0:
-        regions_filter = arguments.regions_filter.split(",")
-
     if arguments.clean and os.path.exists("account-data/{}".format(account_dir)):
         rmtree("account-data/{}".format(account_dir))
 
@@ -221,6 +217,14 @@ def collect(arguments):
         default_region = 'cn-north-1'
     else:
         default_region = 'us-east-1'
+
+    regions_filter = None
+    if len(arguments.regions_filter) > 0:
+        regions_filter = arguments.regions_filter.lower().split(",")
+        # Force include of default region -- seems to be required
+        if default_region not in regions_filter:
+            regions_filter.append(default_region)
+        print("RESTRICTING COLLECTION TO REGIONS: {}".format(regions_filter))
 
     session_data = {"region_name": default_region}
 


### PR DESCRIPTION
This feature adds an optional --regions argument (comma-separated string) to the collect command. If specified, only the region(s) given (plus the default region) will be collected.

Example Usage:
```
python cloudmapper.py collect --regions us-west-2
```

This would result in running collect on both us-west-2 and us-east-1 (in the case of my account).

TESTS:
I am not able to run the package tests, even within pipenv shell:
```
(cloudmapper)  ~/cloudmapper   region-filter  make test
pipenv run -- bash tests/scripts/unit_tests.sh
/Users/tom/.local/share/virtualenvs/cloudmapper-GF7Lg4zO/bin/python: No module named nose
make: *** [test] Error 1
```

Also, I have a very simple AWS account (currently only running a few instances in us-west-2). I discovered running the report is unsuccessful if I don't include us-east-1, so I added the default region if the argument is specified.

I would need assistance testing this on more complex setups, but this feature avoids a lot of calls for describing AWS resources in regions I don't use.


