### PR TITLE
:heavy_plus_sign: Add missing dependencies for drawing stats PNG

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,10 +13,12 @@ Jinja2==2.10.1
 jmespath==0.9.5
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
+matplotlib==3.2.1
 mccabe==0.6.1
 mock==4.0.2
 netaddr==0.7.19
 nose==1.3.7
+pandas==1.0.3
 parliament==0.3.6
 policyuniverse==1.1.0.1
 pycodestyle==2.5.0
@@ -27,6 +29,7 @@ python-dateutil==2.8.1
 PyYAML==4.2b4
 requests==2.22.0
 s3transfer==0.2.1
+seaborn==0.10.1
 six==1.14.0
 toml==0.10.0
 typed-ast==1.4.1


### PR DESCRIPTION
The included dependencies were missing in the new conversion to installation being managed through `pip` and `requirements.txt` file. 

Tested new install in clean `virtualenv` without these packages installed on the host.