### PR TITLE
Call EKS list-clusters before describing

### DIFF
--- a/collect_commands.yaml
+++ b/collect_commands.yaml
@@ -348,7 +348,12 @@
   Request: describe-tasks
   Custom_collection: True
 - Service: eks
+  Request: list-clusters
+- Service: eks
   Request: describe-cluster
+  Parameters:
+  - Name: cluster
+    Value: eks-list-clusters.json|.clusters[]
 - Service: logs
   Request: describe-destinations
 - Service: logs


### PR DESCRIPTION
This fixes #729 by calling EKS `list-clusters` first