### PR TITLE
update docker build to fix #748

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,12 @@ LABEL maintainer="https://github.com/0xdabbad00/"
 LABEL Project="https://github.com/duo-labs/cloudmapper"
 
 EXPOSE 8000
-WORKDIR /opt/cloudmapper
-ENV AWS_DEFAULT_REGION=us-east-1 
+
+ARG AWS_DEFAULT_REGION=us-east-1
 
 RUN apt-get update -y
 RUN apt-get install -y build-essential autoconf automake libtool python3.7-dev python3-tk jq awscli
 RUN apt-get install -y bash
 
-COPY . /opt/cloudmapper
+COPY requirements.txt .
 RUN pip install -r requirements.txt
-
-RUN bash

--- a/README.md
+++ b/README.md
@@ -153,7 +153,10 @@ You may find that you don't care about some of audit items. You may want to igno
 The docker container that is created is meant to be used interactively. 
 
 ```
-docker build -t cloudmapper .
+$ docker build -t cloudmapper .
+
+# Make sure you checkout cloudmapper codes in current folder
+$ docker run -ti -v $(pwd):/apps -p 8000:8000 -w /apps cloudmapper bash
 ```
 
 Cloudmapper needs to make IAM calls and cannot use session credentials for collection, so you cannot use the aws-vault sever if you want to collect data, and must pass role credentials in directly or configure aws credentials manually inside the container. *The following code exposes your raw credentials inside the container.* 
@@ -164,7 +167,8 @@ Cloudmapper needs to make IAM calls and cannot use session credentials for colle
     docker run -ti \
         -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
         -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-        cloudmapper /bin/bash
+        -v $(pwd):/apps -p 8000:8000 -w /apps \
+        cloudmapper bash
 )
 ```
 


### PR DESCRIPTION
With exist Dockerfile, I can't run the demo properly. Issue has been reported in #748

After spend the weekend, I found the `Dockerfile` is going to wrong direction. This PR can drag it back on the right rail.

Changes include:

1) We should not include python source codes directly in Dockerfile, if it is not installed as python packages.
2) the installation pollutes the source codes, that's main reason we got problem #748 
3) simpily the build process. 
4) make **AWS_DEFAULT_REGION** as optional, so we can change it easly by adding `--build-args` with `docker build` command. In fact, I don't recommend to hardcode it when build, we can easily set it as enviroment variable when `docker run` it. 
5) update README for part of `docker run` usage.

