### PR TITLE
Automatic discovery of AWS Organization member accounts to config.json (closes #757)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ python cloudmapper.py configure {add-cidr|remove-cidr} --config-file CONFIG_FILE
 
 This will allow you to define the different AWS accounts you use in your environment and the known CIDR IPs.
 
+If you use [AWS Organizations](https://aws.amazon.com/organizations/), you can also automatically add organization member accounts to `config.json` using:
+
+```
+python cloudmapper.py configure discover-organization-accounts
+```
+
+You need to be authenticated to the AWS CLI and have the permission `organization:ListAccounts` prior to running this command.
+
 
 ### Using audit config overrides
 You may find that you don't care about some of audit items. You may want to ignore the check entirely, or just specific resources.  Copy `config/audit_config_override.yaml.example` to `config/audit_config_override.yaml` and edit the file based on the comments in there.

--- a/shared/organization.py
+++ b/shared/organization.py
@@ -1,0 +1,29 @@
+import boto3
+
+from utils.strings import slugify
+
+# maximum allowed value, c.f. https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccounts.html#API_ListAccounts_RequestSyntax
+MAX_NUM_RESULTS = 20
+
+def get_organization_accounts():
+  organizations_client = boto3.client('organizations')
+  has_more = True
+  next_token = None
+  accounts = []
+
+  while has_more:
+    if next_token:
+      response = organizations_client.list_accounts(MaxResults=MAX_NUM_RESULTS, NextToken=next_token)
+    else:
+      response = organizations_client.list_accounts(MaxResults=MAX_NUM_RESULTS)
+
+    for account in response.get('Accounts', []):
+      accounts.append({
+        "name": slugify(account['Name']),
+        "id": account['Id']
+      })
+    
+    next_token = response.get('NextToken', None)
+    has_more = (next_token is not None)
+  
+  return accounts

--- a/utils/strings.py
+++ b/utils/strings.py
@@ -1,0 +1,12 @@
+# Slugifies a string, e.g.  "My IAM account" => "my-iam-account"
+def slugify(str):
+  allowed_characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
+  new_string = []
+  for i in range(len(str)):
+    char = str[i]
+    if char not in allowed_characters:
+      char = '-'
+    new_string.append(char)
+
+  return ''.join(new_string).strip().lower()
+


### PR DESCRIPTION
c.f. #757. Tested on my AWS Organization (test account). 

Sample run when no `config.json` exists:

```
$ python cloudmapper.py configure discover-organization-accounts
Config file does not exist, creating one
INFO:botocore.credentials:Found credentials in environment variables.

$ cat config.json
{
    "accounts": [
        {
            "id": "0xx9",
            "name": "master"
        },
        {
            "id": "7xx4",
            "name": "dev"
        },
        {
            "id": "4xx1",
            "name": "prod"
        },
        {
            "id": "6xx0",
            "name": "logging"
        },
        {
            "id": "4xx7",
            "name": "security"
        }
    ],
    "cidrs": {}
}
```

Example run when `config.json` exists, but with none of the accounts of the organization:

```
$ cat config.json
{
    "accounts": [
        {
            "id": "111",
            "name": "idontexist"
        }
    ],
    "cidrs": {}
}

$ cloudmapper.py configure discover-organization-accounts

$ cat config.json
{
    "accounts": [
        {
            "id": "111",
            "name": "idontexist"
        },
        {
            "id": "0xx9",
            "name": "master"
        },
        {
            "id": "7xx4",
            "name": "dev"
        },
        {
            "id": "4xx1",
            "name": "prod"
        },
        {
            "id": "6xx0",
            "name": "logging"
        },
        {
            "id": "4xx7",
            "name": "security"
        }
    ],
    "cidrs": {}
}
```

