### PR TITLE
`aws eks describe-cluster` takes --name

### DIFF
--- a/collect_commands.yaml
+++ b/collect_commands.yaml
@@ -352,7 +352,7 @@
 - Service: eks
   Request: describe-cluster
   Parameters:
-  - Name: cluster
+  - Name: name
     Value: eks-list-clusters.json|.clusters[]
 - Service: logs
   Request: describe-destinations


### PR DESCRIPTION
* Working from HEAD of main (9e91a9a) of cloudmapper.
* aws-cli/2.0.50 Python/3.8.5 Darwin/19.6.0 source/x86_64

My collect step failed with:
```
...
Summary: 275 APIs called. 1 errors
Failures:
  eks.describe_cluster({'cluster': 'example-foo'}): Parameter validation failed:
Missing required parameter in input: "name"
```
which led me to: https://github.com/duo-labs/cloudmapper/issues/729
But the AWS CLI/SDK shows that `describe-cluster` takes `--name` not `--cluster`, so this PR changes the parameter we are passing. And allows `collect` to complete successfully.