### PR TITLE
Fix boto3 and s3transfer version pinning conflicts in requirements.txt…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pylint==2.5.2
 python-dateutil==2.8.1
 PyYAML==4.2b4
 requests==2.22.0
-s3transfer==0.2.1
+s3transfer==0.3.0
 seaborn==0.10.1
 six==1.14.0
 toml==0.10.0


### PR DESCRIPTION
…; Fixes #771 when using the supported python version python 3.7 and the public pypi registry

# Without this fix:
```
pip install -i https://pypi.python.org/simple -r requirements.txt --no-cache
Looking in indexes: https://pypi.python.org/simple
Collecting astroid==2.4.1
  Downloading astroid-2.4.1-py3-none-any.whl (214 kB)
     |████████████████████████████████| 214 kB 15.4 MB/s
Collecting autoflake==1.3.1
  Downloading autoflake-1.3.1.tar.gz (17 kB)
Collecting autopep8==1.5.2
  Downloading autopep8-1.5.2.tar.gz (117 kB)
     |████████████████████████████████| 117 kB 46.8 MB/s
Collecting boto3==1.14.6
  Downloading boto3-1.14.6-py2.py3-none-any.whl (128 kB)
     |████████████████████████████████| 128 kB 94.2 MB/s
Collecting botocore==1.17.6
  Downloading botocore-1.17.6-py2.py3-none-any.whl (6.3 MB)
     |████████████████████████████████| 6.3 MB 11.3 MB/s
Collecting certifi==2020.4.5.1
  Downloading certifi-2020.4.5.1-py2.py3-none-any.whl (157 kB)
     |████████████████████████████████| 157 kB 128.4 MB/s
Collecting chardet==3.0.4
  Downloading chardet-3.0.4-py2.py3-none-any.whl (133 kB)
     |████████████████████████████████| 133 kB 131.9 MB/s
Collecting coverage==5.1
  Downloading coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl (227 kB)
     |████████████████████████████████| 227 kB 101.7 MB/s
Collecting docutils==0.15.2
  Downloading docutils-0.15.2-py3-none-any.whl (547 kB)
     |████████████████████████████████| 547 kB 111.8 MB/s
Collecting idna==2.8
  Downloading idna-2.8-py2.py3-none-any.whl (58 kB)
     |████████████████████████████████| 58 kB 101.1 MB/s
Collecting isort==4.3.21
  Downloading isort-4.3.21-py2.py3-none-any.whl (42 kB)
     |████████████████████████████████| 42 kB 53.7 MB/s
Collecting Jinja2==2.10.1
  Downloading Jinja2-2.10.1-py2.py3-none-any.whl (124 kB)
     |████████████████████████████████| 124 kB 129.0 MB/s
Collecting jmespath==0.9.5
  Downloading jmespath-0.9.5-py2.py3-none-any.whl (24 kB)
Collecting lazy-object-proxy==1.4.3
  Downloading lazy_object_proxy-1.4.3-cp37-cp37m-manylinux1_x86_64.whl (56 kB)
     |████████████████████████████████| 56 kB 63.7 MB/s
Collecting MarkupSafe==1.1.1
  Downloading MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl (27 kB)
Collecting matplotlib==3.2.2
  Downloading matplotlib-3.2.2-cp37-cp37m-manylinux1_x86_64.whl (12.4 MB)
     |████████████████████████████████| 12.4 MB 117.0 MB/s
Collecting mccabe==0.6.1
  Downloading mccabe-0.6.1-py2.py3-none-any.whl (8.6 kB)
Collecting mock==4.0.2
  Downloading mock-4.0.2-py3-none-any.whl (28 kB)
Collecting netaddr==0.7.19
  Downloading netaddr-0.7.19-py2.py3-none-any.whl (1.6 MB)
     |████████████████████████████████| 1.6 MB 110.7 MB/s
Collecting nose==1.3.7
  Downloading nose-1.3.7-py3-none-any.whl (154 kB)
     |████████████████████████████████| 154 kB 109.2 MB/s
Collecting pandas==1.0.4
  Downloading pandas-1.0.4-cp37-cp37m-manylinux1_x86_64.whl (10.1 MB)
     |████████████████████████████████| 10.1 MB 22.2 MB/s
Collecting parliament==0.5.0
  Downloading parliament-0.5.0-py3-none-any.whl (276 kB)
     |████████████████████████████████| 276 kB 124.8 MB/s
Collecting policyuniverse==1.1.0.1
  Downloading policyuniverse-1.1.0.1.tar.gz (55 kB)
     |████████████████████████████████| 55 kB 95.1 MB/s
Collecting pycodestyle==2.5.0
  Downloading pycodestyle-2.5.0-py2.py3-none-any.whl (51 kB)
     |████████████████████████████████| 51 kB 94.1 MB/s
Collecting pyflakes==2.2.0
  Downloading pyflakes-2.2.0-py2.py3-none-any.whl (66 kB)
     |████████████████████████████████| 66 kB 105.3 MB/s
Collecting pyjq==2.3.1
  Downloading pyjq-2.3.1.tar.gz (2.1 MB)
     |████████████████████████████████| 2.1 MB 132.2 MB/s
Collecting pylint==2.5.2
  Downloading pylint-2.5.2-py3-none-any.whl (324 kB)
     |████████████████████████████████| 324 kB 126.4 MB/s
Collecting python-dateutil==2.8.1
  Downloading python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
     |████████████████████████████████| 227 kB 125.5 MB/s
Collecting PyYAML==4.2b4
  Downloading PyYAML-4.2b4.tar.gz (262 kB)
     |████████████████████████████████| 262 kB 47.0 MB/s
Collecting requests==2.22.0
  Downloading requests-2.22.0-py2.py3-none-any.whl (57 kB)
     |████████████████████████████████| 57 kB 96.1 MB/s
Collecting s3transfer==0.2.1
  Downloading s3transfer-0.2.1-py2.py3-none-any.whl (70 kB)
     |████████████████████████████████| 70 kB 115.8 MB/s
Collecting seaborn==0.10.1
  Downloading seaborn-0.10.1-py3-none-any.whl (215 kB)
     |████████████████████████████████| 215 kB 135.0 MB/s
Collecting six==1.14.0
  Downloading six-1.14.0-py2.py3-none-any.whl (10 kB)
Collecting toml==0.10.0
  Downloading toml-0.10.0-py2.py3-none-any.whl (25 kB)
Collecting typed-ast==1.4.1
  Downloading typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl (737 kB)
     |████████████████████████████████| 737 kB 106.7 MB/s
Collecting urllib3==1.25.9
  Downloading urllib3-1.25.9-py2.py3-none-any.whl (126 kB)
     |████████████████████████████████| 126 kB 127.6 MB/s
Collecting wrapt==1.12.1
  Downloading wrapt-1.12.1.tar.gz (27 kB)
Collecting kiwisolver>=1.0.1
  Downloading kiwisolver-1.2.0-cp37-cp37m-manylinux1_x86_64.whl (88 kB)
     |████████████████████████████████| 88 kB 113.0 MB/s
Collecting pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1
  Downloading pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
     |████████████████████████████████| 67 kB 99.3 MB/s
Collecting cycler>=0.10
  Downloading cycler-0.10.0-py2.py3-none-any.whl (6.5 kB)
Collecting numpy>=1.11
  Downloading numpy-1.19.2-cp37-cp37m-manylinux2010_x86_64.whl (14.5 MB)
     |████████████████████████████████| 14.5 MB 70.5 MB/s
Collecting pytz>=2017.2
  Downloading pytz-2020.1-py2.py3-none-any.whl (510 kB)
     |████████████████████████████████| 510 kB 123.8 MB/s
Collecting scipy>=1.0.1
  Downloading scipy-1.5.2-cp37-cp37m-manylinux1_x86_64.whl (25.9 MB)
     |████████████████████████████████| 25.9 MB 59.5 MB/s
Building wheels for collected packages: autoflake, autopep8, policyuniverse, pyjq, PyYAML, wrapt
  Building wheel for autoflake (setup.py) ... done
  Created wheel for autoflake: filename=autoflake-1.3.1-py3-none-any.whl size=12384 sha256=52c101725f9c9e101046253a11a5fcd8060bb93d84e3dc123770f3a9ad2519da
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-gn13uib1/wheels/34/66/e4/cdd2a26c72a29d54ebe4f40dd67d239138d29688af7606c799
  Building wheel for autopep8 (setup.py) ... done
  Created wheel for autopep8: filename=autopep8-1.5.2-py2.py3-none-any.whl size=43755 sha256=685c28e58af38129438d38ec1d0d546715451ca3b36a62dcd9916d777150fa9d
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-gn13uib1/wheels/77/ad/47/a9a2cfdfb040efce8838dc52b6b96f8be4fdd63e5cda719eff
  Building wheel for policyuniverse (setup.py) ... done
  Created wheel for policyuniverse: filename=policyuniverse-1.1.0.1-py2.py3-none-any.whl size=55882 sha256=3165cce298ebc6befbbc0986499377424beb253a07f63bfb0aa453b44755ad0f
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-gn13uib1/wheels/38/9c/4b/936402bec0dba5f9ff2109568c78d8885c2cfe7852cbc1799f
  Building wheel for pyjq (setup.py) ... done
  Created wheel for pyjq: filename=pyjq-2.3.1-cp37-cp37m-linux_x86_64.whl size=383208 sha256=5be45c8f18902ef7e159d3c7f0a44b4e2ea7ceaa3074ea976687627e403fb51e
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-gn13uib1/wheels/9b/c8/38/103d7ce5cde860946823d20c52b02b8581ceef5f1134ec33fc
  Building wheel for PyYAML (setup.py) ... done
  Created wheel for PyYAML: filename=PyYAML-4.2b4-cp37-cp37m-linux_x86_64.whl size=396063 sha256=c5da1ee2e7200b2f6644fe8fc8233072cb3d4f9938d772b2b3dbdaea7d0f7fb1
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-gn13uib1/wheels/06/a6/83/224e726cacb89d8d459811ac7c30825ef0afb75192fe934f22
  Building wheel for wrapt (setup.py) ... done
  Created wheel for wrapt: filename=wrapt-1.12.1-cp37-cp37m-linux_x86_64.whl size=64515 sha256=5dda30ae1e89895a392599e77e9c5cc190eace316f734aac9abfb28d660b2568
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-gn13uib1/wheels/62/76/4c/aa25851149f3f6d9785f6c869387ad82b3fd37582fa8147ac6
Successfully built autoflake autopep8 policyuniverse pyjq PyYAML wrapt
ERROR: boto3 1.14.6 has requirement s3transfer<0.4.0,>=0.3.0, but you'll have s3transfer 0.2.1 which is incompatible.
Installing collected packages: typed-ast, wrapt, six, lazy-object-proxy, astroid, pyflakes, autoflake, pycodestyle, autopep8, python-dateutil, urllib3, docutils, jmespath, botocore, s3transfer, boto3, certifi, chardet, coverage, idna, isort, MarkupSafe, Jinja2, kiwisolver, pyparsing, cycler, numpy, matplotlib, mccabe, mock, netaddr, nose, pytz, pandas, PyYAML, parliament, policyuniverse, pyjq, toml, pylint, requests, scipy, seaborn
Successfully installed Jinja2-2.10.1 MarkupSafe-1.1.1 PyYAML-4.2b4 astroid-2.4.1 autoflake-1.3.1 autopep8-1.5.2 boto3-1.14.6 botocore-1.17.6 certifi-2020.4.5.1 chardet-3.0.4 coverage-5.1 cycler-0.10.0 docutils-0.15.2 idna-2.8 isort-4.3.21 jmespath-0.9.5 kiwisolver-1.2.0 lazy-object-proxy-1.4.3 matplotlib-3.2.2 mccabe-0.6.1 mock-4.0.2 netaddr-0.7.19 nose-1.3.7 numpy-1.19.2 pandas-1.0.4 parliament-0.5.0 policyuniverse-1.1.0.1 pycodestyle-2.5.0 pyflakes-2.2.0 pyjq-2.3.1 pylint-2.5.2 pyparsing-2.4.7 python-dateutil-2.8.1 pytz-2020.1 requests-2.22.0 s3transfer-0.2.1 scipy-1.5.2 seaborn-0.10.1 six-1.14.0 toml-0.10.0 typed-ast-1.4.1 urllib3-1.25.9 wrapt-1.12.1

```

# With this fix:
```
pip install -i https://pypi.python.org/simple -r requirements.txt --no-cache
Looking in indexes: https://pypi.python.org/simple
Collecting astroid==2.4.1
  Downloading astroid-2.4.1-py3-none-any.whl (214 kB)
     |████████████████████████████████| 214 kB 20.1 MB/s
Collecting autoflake==1.3.1
  Downloading autoflake-1.3.1.tar.gz (17 kB)
Collecting autopep8==1.5.2
  Downloading autopep8-1.5.2.tar.gz (117 kB)
     |████████████████████████████████| 117 kB 13.6 MB/s
Collecting boto3==1.14.6
  Downloading boto3-1.14.6-py2.py3-none-any.whl (128 kB)
     |████████████████████████████████| 128 kB 46.6 MB/s
Collecting botocore==1.17.6
  Downloading botocore-1.17.6-py2.py3-none-any.whl (6.3 MB)
     |████████████████████████████████| 6.3 MB 99.0 MB/s
Collecting certifi==2020.4.5.1
  Downloading certifi-2020.4.5.1-py2.py3-none-any.whl (157 kB)
     |████████████████████████████████| 157 kB 130.6 MB/s
Collecting chardet==3.0.4
  Downloading chardet-3.0.4-py2.py3-none-any.whl (133 kB)
     |████████████████████████████████| 133 kB 113.4 MB/s
Collecting coverage==5.1
  Downloading coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl (227 kB)
     |████████████████████████████████| 227 kB 123.5 MB/s
Collecting docutils==0.15.2
  Downloading docutils-0.15.2-py3-none-any.whl (547 kB)
     |████████████████████████████████| 547 kB 113.8 MB/s
Collecting idna==2.8
  Downloading idna-2.8-py2.py3-none-any.whl (58 kB)
     |████████████████████████████████| 58 kB 104.6 MB/s
Collecting isort==4.3.21
  Downloading isort-4.3.21-py2.py3-none-any.whl (42 kB)
     |████████████████████████████████| 42 kB 51.4 MB/s
Collecting Jinja2==2.10.1
  Downloading Jinja2-2.10.1-py2.py3-none-any.whl (124 kB)
     |████████████████████████████████| 124 kB 120.7 MB/s
Collecting jmespath==0.9.5
  Downloading jmespath-0.9.5-py2.py3-none-any.whl (24 kB)
Collecting lazy-object-proxy==1.4.3
  Downloading lazy_object_proxy-1.4.3-cp37-cp37m-manylinux1_x86_64.whl (56 kB)
     |████████████████████████████████| 56 kB 91.4 MB/s
Collecting MarkupSafe==1.1.1
  Downloading MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl (27 kB)
Collecting matplotlib==3.2.2
  Downloading matplotlib-3.2.2-cp37-cp37m-manylinux1_x86_64.whl (12.4 MB)
     |████████████████████████████████| 12.4 MB 2.9 MB/s
Collecting mccabe==0.6.1
  Downloading mccabe-0.6.1-py2.py3-none-any.whl (8.6 kB)
Collecting mock==4.0.2
  Downloading mock-4.0.2-py3-none-any.whl (28 kB)
Collecting netaddr==0.7.19
  Downloading netaddr-0.7.19-py2.py3-none-any.whl (1.6 MB)
     |████████████████████████████████| 1.6 MB 103.0 MB/s
Collecting nose==1.3.7
  Downloading nose-1.3.7-py3-none-any.whl (154 kB)
     |████████████████████████████████| 154 kB 130.4 MB/s
Collecting pandas==1.0.4
  Downloading pandas-1.0.4-cp37-cp37m-manylinux1_x86_64.whl (10.1 MB)
     |████████████████████████████████| 10.1 MB 70.5 MB/s
Collecting parliament==0.5.0
  Downloading parliament-0.5.0-py3-none-any.whl (276 kB)
     |████████████████████████████████| 276 kB 82.4 MB/s
Collecting policyuniverse==1.1.0.1
  Downloading policyuniverse-1.1.0.1.tar.gz (55 kB)
     |████████████████████████████████| 55 kB 91.2 MB/s
Collecting pycodestyle==2.5.0
  Downloading pycodestyle-2.5.0-py2.py3-none-any.whl (51 kB)
     |████████████████████████████████| 51 kB 89.4 MB/s
Collecting pyflakes==2.2.0
  Downloading pyflakes-2.2.0-py2.py3-none-any.whl (66 kB)
     |████████████████████████████████| 66 kB 110.4 MB/s
Collecting pyjq==2.3.1
  Downloading pyjq-2.3.1.tar.gz (2.1 MB)
     |████████████████████████████████| 2.1 MB 101.3 MB/s
Collecting pylint==2.5.2
  Downloading pylint-2.5.2-py3-none-any.whl (324 kB)
     |████████████████████████████████| 324 kB 126.9 MB/s
Collecting python-dateutil==2.8.1
  Downloading python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
     |████████████████████████████████| 227 kB 124.3 MB/s
Collecting PyYAML==4.2b4
  Downloading PyYAML-4.2b4.tar.gz (262 kB)
     |████████████████████████████████| 262 kB 128.8 MB/s
Collecting requests==2.22.0
  Downloading requests-2.22.0-py2.py3-none-any.whl (57 kB)
     |████████████████████████████████| 57 kB 93.2 MB/s
Collecting s3transfer==0.3.0
  Downloading s3transfer-0.3.0-py2.py3-none-any.whl (69 kB)
     |████████████████████████████████| 69 kB 119.5 MB/s
Collecting seaborn==0.10.1
  Downloading seaborn-0.10.1-py3-none-any.whl (215 kB)
     |████████████████████████████████| 215 kB 137.7 MB/s
Collecting six==1.14.0
  Downloading six-1.14.0-py2.py3-none-any.whl (10 kB)
Collecting toml==0.10.0
  Downloading toml-0.10.0-py2.py3-none-any.whl (25 kB)
Collecting typed-ast==1.4.1
  Downloading typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl (737 kB)
     |████████████████████████████████| 737 kB 63.9 MB/s
Collecting urllib3==1.25.9
  Downloading urllib3-1.25.9-py2.py3-none-any.whl (126 kB)
     |████████████████████████████████| 126 kB 132.5 MB/s
Collecting wrapt==1.12.1
  Downloading wrapt-1.12.1.tar.gz (27 kB)
Collecting kiwisolver>=1.0.1
  Downloading kiwisolver-1.2.0-cp37-cp37m-manylinux1_x86_64.whl (88 kB)
     |████████████████████████████████| 88 kB 112.0 MB/s
Collecting numpy>=1.11
  Downloading numpy-1.19.2-cp37-cp37m-manylinux2010_x86_64.whl (14.5 MB)
     |████████████████████████████████| 14.5 MB 70.6 MB/s
Collecting cycler>=0.10
  Downloading cycler-0.10.0-py2.py3-none-any.whl (6.5 kB)
Collecting pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1
  Downloading pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
     |████████████████████████████████| 67 kB 100.2 MB/s
Collecting pytz>=2017.2
  Downloading pytz-2020.1-py2.py3-none-any.whl (510 kB)
     |████████████████████████████████| 510 kB 111.7 MB/s
Collecting scipy>=1.0.1
  Downloading scipy-1.5.2-cp37-cp37m-manylinux1_x86_64.whl (25.9 MB)
     |████████████████████████████████| 25.9 MB 105.4 MB/s
Building wheels for collected packages: autoflake, autopep8, policyuniverse, pyjq, PyYAML, wrapt
  Building wheel for autoflake (setup.py) ... done
  Created wheel for autoflake: filename=autoflake-1.3.1-py3-none-any.whl size=12384 sha256=994d999dff6a5d5488f3c39dc191d32c808f76b5041d14eb92c6010f69d8dbbb
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-2re7k8g8/wheels/34/66/e4/cdd2a26c72a29d54ebe4f40dd67d239138d29688af7606c799
  Building wheel for autopep8 (setup.py) ... done
  Created wheel for autopep8: filename=autopep8-1.5.2-py2.py3-none-any.whl size=43755 sha256=ef15d4aeb0ec9c5f363e47e863c7495a9fdc3a56178447b1e49d9a3727226582
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-2re7k8g8/wheels/77/ad/47/a9a2cfdfb040efce8838dc52b6b96f8be4fdd63e5cda719eff
  Building wheel for policyuniverse (setup.py) ... done
  Created wheel for policyuniverse: filename=policyuniverse-1.1.0.1-py2.py3-none-any.whl size=55882 sha256=a59c6b43d9373dc65af59959b6d778afbc6b5241c7d5f467fb3fea97515a253c
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-2re7k8g8/wheels/38/9c/4b/936402bec0dba5f9ff2109568c78d8885c2cfe7852cbc1799f
  Building wheel for pyjq (setup.py) ... done
  Created wheel for pyjq: filename=pyjq-2.3.1-cp37-cp37m-linux_x86_64.whl size=383209 sha256=d81ad5460be25e2789e0f839b817c8cd3050510be8ee02dd68cbdb47c2d94773
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-2re7k8g8/wheels/9b/c8/38/103d7ce5cde860946823d20c52b02b8581ceef5f1134ec33fc
  Building wheel for PyYAML (setup.py) ... done
  Created wheel for PyYAML: filename=PyYAML-4.2b4-cp37-cp37m-linux_x86_64.whl size=396069 sha256=dded3f2d03faf7196cd10e32cb023c21d6b78b0f54f50844e3cb353dab3c0f65
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-2re7k8g8/wheels/06/a6/83/224e726cacb89d8d459811ac7c30825ef0afb75192fe934f22
  Building wheel for wrapt (setup.py) ... done
  Created wheel for wrapt: filename=wrapt-1.12.1-cp37-cp37m-linux_x86_64.whl size=64514 sha256=4c6abc513553407a31d7439e527406b1d4cb17ec3299f8bac0f37335d8f38a95
  Stored in directory: /nail/tmp/pip-ephem-wheel-cache-2re7k8g8/wheels/62/76/4c/aa25851149f3f6d9785f6c869387ad82b3fd37582fa8147ac6
Successfully built autoflake autopep8 policyuniverse pyjq PyYAML wrapt
Installing collected packages: lazy-object-proxy, wrapt, typed-ast, six, astroid, pyflakes, autoflake, pycodestyle, autopep8, urllib3, python-dateutil, jmespath, docutils, botocore, s3transfer, boto3, certifi, chardet, coverage, idna, isort, MarkupSafe, Jinja2, kiwisolver, numpy, cycler, pyparsing, matplotlib, mccabe, mock, netaddr, nose, pytz, pandas, PyYAML, parliament, policyuniverse, pyjq, toml, pylint, requests, scipy, seaborn
Successfully installed Jinja2-2.10.1 MarkupSafe-1.1.1 PyYAML-4.2b4 astroid-2.4.1 autoflake-1.3.1 autopep8-1.5.2 boto3-1.14.6 botocore-1.17.6 certifi-2020.4.5.1 chardet-3.0.4 coverage-5.1 cycler-0.10.0 docutils-0.15.2 idna-2.8 isort-4.3.21 jmespath-0.9.5 kiwisolver-1.2.0 lazy-object-proxy-1.4.3 matplotlib-3.2.2 mccabe-0.6.1 mock-4.0.2 netaddr-0.7.19 nose-1.3.7 numpy-1.19.2 pandas-1.0.4 parliament-0.5.0 policyuniverse-1.1.0.1 pycodestyle-2.5.0 pyflakes-2.2.0 pyjq-2.3.1 pylint-2.5.2 pyparsing-2.4.7 python-dateutil-2.8.1 pytz-2020.1 requests-2.22.0 s3transfer-0.3.0 scipy-1.5.2 seaborn-0.10.1 six-1.14.0 toml-0.10.0 typed-ast-1.4.1 urllib3-1.25.9 wrapt-1.12.1
```