### PR TITLE
Support missing tasks OR multiple tasks per task ARN. Fixes #785

### DIFF
--- a/commands/prepare.py
+++ b/commands/prepare.py
@@ -144,7 +144,8 @@ def get_ecs_tasks(region):
                 urllib.parse.quote_plus(taskArn),
             )
             task = json.load(open(task_path))
-            tasks.append(task["tasks"][0])
+            for task in task["tasks"]:
+                tasks.append(task)
     return tasks
 
 


### PR DESCRIPTION
Fixes the Index out of range error in case a collected task is in the failure state for some reason or another.