### PR TITLE
update pandas version from 1.0.4 to 1.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ mccabe==0.6.1
 mock==4.0.2
 netaddr==0.7.19
 nose==1.3.7
-pandas==1.0.4
+pandas==1.1.4
 parliament==0.5.0
 policyuniverse==1.1.0.1
 pycodestyle==2.5.0


### PR DESCRIPTION
currently installing dependencies fails in the virtual environment due to the requirements.txt fie containing an old version of pandas. I've just updated that one line. 