### PR TITLE
Desync mitigation check on ELBv1

### DIFF
--- a/audit_config.yaml
+++ b/audit_config.yaml
@@ -388,3 +388,9 @@ REQUEST_SMUGGLING:
   description: "HTTP request smuggling is possible against ALBs, as described here: https://portswigger.net/web-security/request-smuggling"
   severity: Low
   group: ELB
+
+ELBV1_DESYNC_MITIGATION:
+  title: Desync mitigation mode not configured
+  description: "Desync mitigation mode protects your application from issues due to HTTP Desync and should be set to 'Strictest'. https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-desync-mitigation-mode.html"
+  severity: Low
+  group: ELB

--- a/collect_commands.yaml
+++ b/collect_commands.yaml
@@ -134,6 +134,11 @@
 - Service: elb
   Request: describe-load-balancers
 - Service: elb
+  Request: describe-load-balancer-attributes
+  Parameters:
+  - Name: LoadBalancerName
+    Value: elb-describe-load-balancers.json|.LoadBalancerDescriptions[].LoadBalancerName
+- Service: elb
   Request: describe-load-balancer-policies
 - Service: elb
   Request: describe-tags


### PR DESCRIPTION
Based on [recommended guidance](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-desync-mitigation-mode.html) from AWS, sets a new `ELBV1_DESYNC_MITIGATION` check.

This change includes:

- A new audit_config
- `describe-load-balancer-attributes` collection task, 
- The check logic in `audit.py`,

The check is very similar to the ELBv2 check, but targets a different resource in a different way. 
I don't believe they should be merged, but happy to do so, if needed.