### PR TITLE
Cleaner reporting

### DIFF
--- a/auditor/lib/cloudmapperauditor-stack.js
+++ b/auditor/lib/cloudmapperauditor-stack.js
@@ -62,7 +62,8 @@ class CloudmapperauditorStack extends cdk.Stack {
       cpu: 256,
       environment: {
         S3_BUCKET: config['s3_bucket'],
-        MINIMUM_ALERT_SEVERITY: config['minimum_alert_severity']
+        MINIMUM_ALERT_SEVERITY: config['minimum_alert_severity'],
+        MINIMUM_REPORT_SEVERITY: config['minimum_report_severity']
       },
       logging: new ecs.AwsLogDriver({
         streamPrefix: 'cloudmapper',

--- a/auditor/s3_bucket_files/cdk_app.yaml
+++ b/auditor/s3_bucket_files/cdk_app.yaml
@@ -11,3 +11,6 @@ iam_role: CloudMapper
 
 # Minimum severity of the alerts sent to Slack
 minimum_alert_severity: "LOW"
+
+# Minimum severity of the findings in report
+minimum_report_severity: "INFO"

--- a/auditor/s3_bucket_files/run_cloudmapper.sh
+++ b/auditor/s3_bucket_files/run_cloudmapper.sh
@@ -63,21 +63,24 @@ if [ $? -ne 0 ]; then
 fi
 
 # Copy the collect data to the S3 bucket
-aws s3 sync --delete account-data/ s3://$S3_BUCKET/account-data/
+echo "Exporting account data"
+aws s3 sync --no-progress --quiet --delete account-data/ s3://$S3_BUCKET/account-data/
 if [ $? -ne 0 ]; then
     echo "ERROR: syncing account-data failed"
     aws cloudwatch put-metric-data --namespace cloudmapper --metric-data MetricName=errors,Value=1
 fi
 
 # Copy the logs to the S3 bucket
-aws s3 sync --delete collect_logs/ s3://$S3_BUCKET/collect_logs/
+echo "Exporting collection logs"
+aws s3 sync --no-progress --quiet --delete collect_logs/ s3://$S3_BUCKET/collect_logs/
 if [ $? -ne 0 ]; then
     echo "ERROR: syncing the collection logs failed"
     aws cloudwatch put-metric-data --namespace cloudmapper --metric-data MetricName=errors,Value=1
 fi
 
 # Copy the report to the S3 bucket
-aws s3 sync --delete web/ s3://$S3_BUCKET/web/
+echo "Exporting web report"
+aws s3 sync --no-progress --quiet --delete web/ s3://$S3_BUCKET/web/
 if [ $? -ne 0 ]; then
     echo "ERROR: syncing web directory failed"
     aws cloudwatch put-metric-data --namespace cloudmapper --metric-data MetricName=errors,Value=1

--- a/auditor/s3_bucket_files/run_cloudmapper.sh
+++ b/auditor/s3_bucket_files/run_cloudmapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Runnning run_cloudmapper"
+echo "Running run_cloudmapper"
 
 # Configure the AWS SDK so we can assume roles
 mkdir ~/.aws
@@ -57,7 +57,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Generate the report"
-python cloudmapper.py report --accounts all
+python cloudmapper.py report --accounts all --minimum_severity $MINIMUM_REPORT_SEVERITY
 if [ $? -ne 0 ]; then
     echo "ERROR: The report command had an error"
     aws cloudwatch put-metric-data --namespace cloudmapper --metric-data MetricName=errors,Value=1
@@ -95,5 +95,4 @@ if grep "Summary:" collect_logs/* | grep -v '0 errors'; then
   grep "Summary:" collect_logs/* | python ./utils/toslack.py
 else
   echo "Completed CloudMapper audit" | python ./utils/toslack.py
-
 fi

--- a/commands/report.py
+++ b/commands/report.py
@@ -343,7 +343,7 @@ def report(accounts, config, args):
         for _ in accounts:
             severity_counts_by_account.append(
                 len(
-                    findings_severity_by_account[finding.account_name][severity["name"]]
+                    findings_severity_by_account[_["name"]][severity["name"]]
                 )
             )
 
@@ -462,7 +462,7 @@ def run(arguments):
     )
     parser.add_argument(
         "--minimum_severity",
-        help="Only report issues that are greater than this. Default: LOW",
+        help="Only report issues that are greater than this. Default: INFO",
         default="INFO",
         choices=['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFO', 'MUTE']
     )

--- a/shared/audit.py
+++ b/shared/audit.py
@@ -914,7 +914,13 @@ def audit_sg(findings, region):
                                 region,
                                 "SG_CIDR_OVERLAPS",
                                 sg["GroupId"],
-                                resource_details={"cidr1": cidr, "cidr2": cidr_seen},
+                                resource_details={
+                                    "SG name:": sg["GroupName"],
+                                    "SG description": sg["Description"],
+                                    "SG tags": sg.get("Tags", {}),
+                                    "cidr1": cidr,
+                                    "cidr2": cidr_seen
+                                },
                             )
                         )
                 cidrs_seen.add(cidr)
@@ -929,6 +935,7 @@ def audit_sg(findings, region):
                     cidr,
                     resource_details={
                         "size": ip.size,
+                        "IP info": str(ip.info),
                         "security_groups": list(cidrs[cidr]),
                     },
                 )

--- a/shared/audit.py
+++ b/shared/audit.py
@@ -781,7 +781,10 @@ def audit_ec2(findings, region):
                             instance["InstanceId"],
                             resource_details={
                                 "Name": get_name(instance, "InstanceId"),
+                                "Instance ID": instance["InstanceId"],
                                 "Tags": instance.get("Tags", {}),
+                                "MetadataOptions": instance["MetadataOptions"],
+                                "SSH Key Found": instance.get("KeyName", {}),
                             },
                         )
                     )

--- a/shared/audit.py
+++ b/shared/audit.py
@@ -167,7 +167,7 @@ def audit_s3_buckets(findings, region):
             )
 
 
-def audit_s3_block_policy(findings, region):
+def audit_s3_block_policy(findings, region, account_name):
     caller_identity_json = query_aws(region.account, "sts-get-caller-identity", region)
     block_policy_json = get_parameter_file(
         region, "s3control", "get-public-access-block", caller_identity_json["Account"]
@@ -186,7 +186,7 @@ def audit_s3_block_policy(findings, region):
                 Finding(
                     region,
                     "S3_ACCESS_BLOCK_ALL_ACCESS_TYPES",
-                    None,
+                    account_name,
                     resource_details=block_policy_json,
                 )
             )
@@ -1151,7 +1151,7 @@ def audit(accounts):
                     audit_users(findings, region)
                     audit_route53(findings, region)
                     audit_cloudfront(findings, region)
-                    audit_s3_block_policy(findings, region)
+                    audit_s3_block_policy(findings, region, account.name)
                 audit_guardduty(findings, region)
                 audit_accessanalyzer(findings, region)
                 audit_ebs_snapshots(findings, region)

--- a/shared/iam_audit.py
+++ b/shared/iam_audit.py
@@ -18,7 +18,7 @@ from shared.nodes import Account, Region
 getLogger("policyuniverse").setLevel(CRITICAL)
 KNOWN_BAD_POLICIES = {
     "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM": "Use AmazonSSMManagedInstanceCore instead and add privs as needed",
-    "arn:aws:iam::aws:policy/service-role/AmazonMachineLearningRoleforRedshiftDataSource": "Use AmazonMachineLearningRoleforRedshiftDataSourceV2 instead",
+    "arn:aws:iam::aws:policy/service-role/AmazonMachineLearningRoleforRedshiftDataSource": "Use AmazonMachineLearningRoleforRedshiftDataSourceV3 instead",
 }
 
 


### PR DESCRIPTION
This PR aims to enhance the capabilities of the reporting command.
- Sets a new `MINIMUM_REPORT_SEVERITY` that complements the slack `MINIMUM_ALERT_SEVERITY` variable. This variable is defined in `cdk_app.yaml` and defaults to INFO. This is useful for accounts with a large number of INFO-level findings. (ex: `IAM_LINTER`)
- Enables detailed error reporting in Slack. Currently, non-blocking API errors will appear in collect logs and in Cloudwatch. This change allows per-account error counts to be presented. If no errors are detected, previous output message behavior is maintained.
- Suppresses the 1000's of cloudwatch log lines that come from the upload/sync actions from ECS to S3.
- Fixes the `counts-of-findings-by-account` graph in `report.html`
- Clarifies (but does not alter) the existing default minimum severity filter for the `report` command.
- Updates `KNOWN_BAD_POLICIES` to reference the new, safe V3 policy for `AmazonMachineLearningRoleforRedshiftDataSourceV3`
- `audit_s3_block_policy()` will emit `account_name` in `Finding()` to quickly root cause the offending account.
- `EC2_IMDSV2_NOT_ENFORCED` now provides the current MetaData Options to measure against. Also provides the ssh_key and instance ID, to assist with finding resources and determining risk.
- `SG_CIDR_OVERLAPS` and `SG_LARGE_CIDR` attempt to provide Security Group descriptive information.