### PR TITLE
New vendors

### DIFF
--- a/vendor_accounts.yaml
+++ b/vendor_accounts.yaml
@@ -188,3 +188,12 @@
 - name: 'Emnify'
   source: 'https://www.emnify.com/datastreamer-integration-into-aws'
   accounts: ['884047677700']
+- name: 'Cisco Umbrella'
+  source: 'https://docs.umbrella.com/umbrella-user-guide/docs/enable-logging-to-your-own-s3-bucket'
+  accounts: ['568526795995']
+- name: 'Cloudflare'
+  source: 'https://developers.cloudflare.com/logs/logpush/aws-s3'
+  accounts: ['391854517948']
+- name: '[Deprecated] AWS Log delivery Service'
+  source: 'https://forums.aws.amazon.com/thread.jspa?messageID=629256'
+  accounts: ['858827067514']


### PR DESCRIPTION
Adds 3 new vendors to the `vendor_accounts.yaml` list.
- Cisco Umbrella
- Cloudflare
- AWS S3 Log Delivery Service

Note: AWS no longer recommends using the S3 Log Delivery Service with this AWS account and instead recommends you to use ""s3.amazonaws.com"" in principal.