### PR TITLE
Web of trust STS

### DIFF
--- a/commands/weboftrust.py
+++ b/commands/weboftrust.py
@@ -5,7 +5,7 @@ import yaml
 import pyjq
 import urllib.parse
 
-from shared.common import parse_arguments, make_list, query_aws, get_regions
+from shared.common import parse_arguments, make_list, query_aws, get_regions, get_account_by_id
 
 __description__ = "Create Web Of Trust diagram for accounts"
 
@@ -191,7 +191,15 @@ def get_iam_trusts(account, nodes, connections, connections_to_get):
 
                 for federated_principal in federated_principals:
                     try:
-                        saml_provider_arn = next(saml for saml in saml_providers if saml['Arn'] == federated_principal)['Arn']
+                        # Validate that the federated principal and the SAML provider is coming from known accounts.
+                        # WoT will show us the direction of that trust for further inspection.
+                        # this enables cross_account_admin_sts (STS between accounts)
+                        for saml in saml_providers:
+                            if saml['Arn'] == federated_principal:
+                                saml_provider_arn = saml['Arn']
+                            elif get_account_by_id(account_id=federated_principal.split(':')[4]):
+                                if get_account_by_id(account_id=saml['Arn'].split(':')[4]):
+                                    saml_provider_arn = saml['Arn']
 
                         if 'saml-provider/okta' in saml_provider_arn.lower():
                             node = Account(
@@ -269,7 +277,7 @@ def get_iam_trusts(account, nodes, connections, connections_to_get):
                                 "Unknown federation provider: {}".format(saml_provider_arn.lower())
                             )
 
-                    except StopIteration:
+                    except (StopIteration, IndexError):
                         if "cognito-identity.amazonaws.com" in federated_principal.lower():
                             # TODO: Should show this somehow
                             continue

--- a/shared/audit.py
+++ b/shared/audit.py
@@ -721,6 +721,8 @@ def audit_es(findings, region):
         )
         # Find the entity we need
         policy_string = policy_file_json["DomainStatus"]["AccessPolicies"]
+        if policy_string == '':
+            policy_string = "{}"
         # Load the string value as json
         policy = json.loads(policy_string)
         policy = Policy(policy)
@@ -729,10 +731,9 @@ def audit_es(findings, region):
         # they are VPC-only, in which case they have an "Endpoints" (plural) array containing a "vpc" element
         if (
             policy_file_json["DomainStatus"].get("Endpoint", "") != ""
-            or policy_file_json["DomainStatus"].get("Endpoints", {}).get("vpc", "")
-            == ""
+            or policy_file_json["DomainStatus"].get("Endpoints", {}).get("vpc", "") == ""
         ):
-            if policy.is_internet_accessible():
+            if policy.is_internet_accessible() or policy_string == "{}":
                 findings.add(
                     Finding(region, "ES_PUBLIC", name, resource_details=policy_string)
                 )

--- a/shared/common.py
+++ b/shared/common.py
@@ -186,6 +186,30 @@ def get_account(account_name, config=None, config_filename="config.json.demo"):
     )
 
 
+def get_account_by_id(account_id, config=None, config_filename="config.json"):
+    if config is None:
+        config = json.load(open(config_filename))
+
+    for account in config["accounts"]:
+        if account["id"] == account_id:
+            return account
+        if account_id is None and account.get("default", False):
+            return account
+
+    # Else could not find account
+    if account_id is None:
+        exit(
+            "ERROR: Must specify an account, or set one in {} as a default".format(
+                config_filename
+            )
+        )
+    exit(
+        'ERROR: Account ID "{}" not found in {}'.format(
+            account_id, config_filename
+        )
+    )
+
+
 def parse_arguments(arguments, parser=None):
     """Returns (args, accounts, config)"""
     if parser is None:

--- a/web/style.json
+++ b/web/style.json
@@ -27,6 +27,7 @@
         "selector": "edge.admin",
         "style": {
             "width": 10,
+            "label": "admin",
             "line-color": "#f00",
             "target-arrow-color": "#f00"
         }
@@ -35,6 +36,7 @@
         "selector": "edge.assume_role",
         "style": {
             "line-color": "#999",
+            "label": "assume_role",
             "target-arrow-color": "#999"
         }
     },
@@ -43,6 +45,7 @@
         "style": {
             "line-color": "#999",
             "target-arrow-color": "#999",
+            "label": "assume_role_read",
             "line-style": "dashed"
         }
     },
@@ -50,6 +53,7 @@
         "selector": "edge.cloudtrail",
         "style": {
             "line-color": "#090",
+            "label": "cloudtrail",
             "target-arrow-color": "#090"
         }
     },
@@ -58,6 +62,7 @@
         "selector": "edge.s3_read",
         "style": {
             "line-color": "#fc0",
+            "label": "s3_read",
             "target-arrow-color": "#fc0",
             "line-style": "dashed"
         }
@@ -67,6 +72,7 @@
         "selector": "edge.s3",
         "style": {
             "line-color": "#fc0",
+            "label": "s3",
             "target-arrow-color": "#fc0"
         }
     },
@@ -74,6 +80,7 @@
         "selector": "edge.vpc",
         "style": {
             "line-color": "#36f",
+            "label": "vpc peering",
             "target-arrow-color": "#36f",
             "target-arrow-shape": "none"
         }
@@ -83,6 +90,7 @@
         "style": {
             "line-color": "#36f",
             "line-style": "dashed",
+            "label": "directconnect",
             "target-arrow-color": "#36f",
             "target-arrow-shape": "none"
         }


### PR DESCRIPTION
With cross-account STS-based authentication backed by SAML, this WoT failed to execute as the the two Arn's would never match. (The principal and the provider are not in the same account, by design.)

Here, we replicate the same behavior as before, but also add a fallback model of ensuring we actually trust the origin and target accounts. This allows WoT to graph the unidirectional trust for further inspection.

Additionally, `web/style.json` now includes labels to better understand what the colors mean at a glance. While this data is also available [here](https://summitroute.com/blog/2018/06/13/cloudmapper_wot), it's easier to share the WoT graph with all data present.

Lastly, ensured that any elasticsearch instance without an attached AccessPolicy be marked as `ES_PUBLIC` due to undocumented and unexpected behavior. Normally, AWS does not allow you to create a policy-less ES cluster, but there appears to be a way to create this state using the terraform provider.