### PR TITLE
Improve aws-vault/docker run documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,17 +164,17 @@ The docker container that is created is meant to be used interactively.
 docker build -t cloudmapper .
 ```
 
-Cloudmapper needs to make IAM calls and cannot use session credentials for collection, so you cannot use the aws-vault server if you want to collect data, and must pass role credentials in directly or configure aws credentials manually inside the container. *The following code exposes your raw credentials inside the container.* 
+Cloudmapper needs to make AWS API calls using your aws credentials inside the container. Thanks to aws-vault, only your session credentials are exposed inside the container. Mounting the cloned repo directory (usually current directory) into `/opt/cloudmapper` also helps preserving `account-data` and configuration files.
 
 ```
-(                                                              
-    export $(aws-vault exec YOUR_PROFILE --no-session -- env | grep ^AWS | xargs) && \ 
-    docker run -ti \
-        -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-        -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-        -p 8000:8000 \
-        cloudmapper /bin/bash
-)
+aws-vault exec YOUR_PROFILE -- \
+docker run -ti \
+    -e AWS_ACCESS_KEY_ID \
+    -e AWS_SECRET_ACCESS_KEY \
+    -e AWS_SESSION_TOKEN \
+    -v "$(pwd)/":/opt/cloudmapper/ \
+    -p 8000:8000 \
+    cloudmapper /bin/bash
 ```
 
 This will drop you into the container. Run `aws sts get-caller-identity` to confirm this was setup correctly. Cloudmapper demo data is not copied into the docker container so you will need to collect live data from your system. Note docker defaults may limit the memory available to your container. For example on Mac OS the default is 2GB which may not be enough to generate the report on a medium sized account.


### PR DESCRIPTION
Hello duo-labs team,

I improved the instructions for aws-vault and docker run with the following changes:

- Use aws-vault with session tokens instead of raw credentials
- Mount cloned cloudmapper directory inside the container to preserve data collection

Testing AWS credentials:

```
root@a0c4d5b34c92:/opt/cloudmapper# aws sts get-caller-identity
{
    "UserId": "AROAXXXXXXXXXXXXXXXXX:rafops",
    "Account": "111111111111",
    "Arn": "arn:aws:sts::111111111111:assumed-role/cloudmapper-role/rafops"
}
```

I ran the collection successfully in a relatively large account without any issues. Here are the results:

Collection:
```
root@a0c4d5b34c92:/opt/cloudmapper# python cloudmapper.py collect --account prod
* Getting region names
* Creating directory for each region name
* Getting iam:generate-credential-report info
...
--------------------------------------------------------------------
Summary: 2436 APIs called. 0 errors
```

All the best and happy holidays!