### PR TITLE
Add freetype to brew install pre-reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ On macOS:
 # clone the repo
 git clone https://github.com/duo-labs/cloudmapper.git
 # Install pre-reqs for pyjq
-brew install autoconf automake libtool jq awscli python3
+brew install autoconf automake awscli freetype jq libtool python3
 cd cloudmapper/
 python3 -m venv ./venv && source venv/bin/activate
 pip install -r requirements.txt


### PR DESCRIPTION
When running `pip install`, it error-ed out because I didn't have FreeType installed. This was the specific message:
```
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -DFREETYPE_BUILD_TYPE=system -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ft2font_ARRAY_API -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -D__STDC_FORMAT_MACROS=1 -Iextern/agg24-svn/include -I/Users/brandonhigh/.asdf/installs/python/3.9.0/lib/python3.9/site-packages/numpy/core/include -I/Users/brandonhigh/.asdf/installs/python/3.9.0/include/python3.9 -c src/checkdep_freetype2.c -o build/temp.macosx-10.15-x86_64-3.9/src/checkdep_freetype2.o
    src/checkdep_freetype2.c:3:6: error: "FreeType version 2.3 or higher is required. You may set the MPLLOCALFREETYPE environment variable to 1 to let Matplotlib download it."
        #error "FreeType version 2.3 or higher is required. \
         ^
    src/checkdep_freetype2.c:9:10: fatal error: 'ft2build.h' file not found
    #include <ft2build.h>
             ^~~~~~~~~~~~
    2 errors generated.
    error: command '/usr/bin/clang' failed with exit code 1
```
After `brew install freetype`, I was able to `pip install` with no issues.