### PR TITLE
Fix issue 822

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ auditor/.cdk.staging
 auditor/cdk.out
 auditor/.env
 auditor/resources/cloudmapper
+
+# IntelliJ IDEA files and folders
+.idea

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ mock==4.0.2
 netaddr==0.7.19
 nose==1.3.7
 pandas==1.1.3
-parliament==0.5.0
+parliament==1.3.1
 policyuniverse==1.3.2.20201103
 pycodestyle==2.5.0
 pyflakes==2.2.0


### PR DESCRIPTION
Increase version of parliament to latest published -> 1.3.1
As seen in https://pypi.org/project/parliament/#history and in https://github.com/duo-labs/parliament/releases .

Updated `.gitignore` so it ignores IntelliJ IDEA files and folders

Fixes issue https://github.com/duo-labs/cloudmapper/issues/822