### PR TITLE
Fix issue 803

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Jinja2==2.10.1
 jmespath==0.9.5
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
-matplotlib==3.2.2
+matplotlib==3.3.3
 mccabe==0.6.1
 mock==4.0.2
 netaddr==0.7.19


### PR DESCRIPTION
As commented in https://github.com/duo-labs/cloudmapper/issues/803 the solution from @BenDenney (https://github.com/BenDenney) was to increase `matplotlib` to `3.3.3`