### PR TITLE
Update README.md for aws-vault compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Cloudmapper needs to make IAM calls and cannot use session credentials for colle
     docker run -ti \
         -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
         -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+        -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
         -p 8000:8000 \
         cloudmapper /bin/bash
 )


### PR DESCRIPTION
It is required to also include the `AWS_SESSION_TOKEN` env variable when using aws-vault / Docker.