### PR TITLE
(deps) update packages to closest available with arm64 binary distribution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,8 @@ mccabe==0.6.1
 mock==4.0.3
 netaddr==0.8.0
 nose==1.3.7
-numpy==1.21.3
-pandas==1.3.4
+numpy==1.22.3
+pandas==1.4.1
 parliament==1.5.2
 Pillow==8.4.0
 platformdirs==2.4.0
@@ -39,11 +39,11 @@ pytz==2021.3
 PyYAML==6.0
 requests==2.26.0
 s3transfer==0.5.0
-scipy==1.7.1
+scipy==1.7.3
 seaborn==0.11.2
 six==1.16.0
 toml==0.10.2
-typed-ast==1.4.3
+typed-ast==1.5.2
 typing-extensions==3.10.0.2
 urllib3==1.26.7
 wrapt==1.13.3


### PR DESCRIPTION
This pull requests updates packages in `requirements.txt` to the nearest minor version with binary distribution for arm64. This makes it possible to use cloudmapper directly on a M1 mac.