### PR TITLE
Add Slack EKM's AWS account numbers

### DIFF
--- a/vendor_accounts.yaml
+++ b/vendor_accounts.yaml
@@ -363,3 +363,6 @@
   type: 'aws'
   source: 'https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-api-with-vpclink-accounts.html'
   accounts: ['392220576650', '718770453195', '968246515281', '109351309407', '796887884028', '631144002099', '544388816663', '061510835048', '474240146802', '394634713161', '969236854626', '020402002396', '195145609632', '798376113853', '507069717855', '174803364771', '287228555773', '855739686837']
+- name: 'Slack EKM'
+  source: 'https://slackhq.com/dotcom/dotcom/wp-content/uploads/sites/6/2019/08/Slack-EKM-Implementation-Guide-1.pdf'
+  accounts: ['152659312504', '429538831549']


### PR DESCRIPTION
Slack EKM integrates Slack with AWS KMS in the customers' AWS account to provide visibility into and control over the encryption keys Slack uses to encrypt that customer's messages and files. Customers see these two Slack AWS account numbers in their CloudTrail logs when using Slack EKM.