### PR TITLE
Fixes exception when parameter file missing

### DIFF
--- a/shared/common.py
+++ b/shared/common.py
@@ -303,7 +303,10 @@ def get_account_stats(account, all_resources=False):
                         # Get the bucket's location
                         bucket_region = get_parameter_file(
                             region, "s3", "get-bucket-location", bucket
-                        )["LocationConstraint"]
+                        )
+                        
+                        if bucket_region:
+                            bucket_region = bucket_region.get("LocationConstraint")
 
                         # Convert the value to a name.
                         # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region


### PR DESCRIPTION
I'm getting following exception when run report.

```
root@91107bedf108:/opt/cloudmapper# python cloudmapper.py report --account st
* Getting resource counts
Traceback (most recent call last):
  File "cloudmapper.py", line 72, in <module>
    main()
  File "cloudmapper.py", line 66, in main
    commands[command].run(arguments)
  File "/opt/cloudmapper/commands/report.py", line 476, in run
    report(accounts, config, args)
  File "/opt/cloudmapper/commands/report.py", line 102, in report
    account, args.stats_all_resources
  File "/opt/cloudmapper/shared/common.py", line 306, in get_account_stats
    )["LocationConstraint"]
TypeError: 'NoneType' object is not subscriptable
```