### PR TITLE
added observed wiz account ids

### DIFF
--- a/vendor_accounts.yaml
+++ b/vendor_accounts.yaml
@@ -366,3 +366,6 @@
 - name: 'Slack EKM'
   source: 'https://slackhq.com/dotcom/dotcom/wp-content/uploads/sites/6/2019/08/Slack-EKM-Implementation-Guide-1.pdf'
   accounts: ['152659312504', '429538831549']
+- name: 'Wiz'
+  source: 'observed in multiple customer environments'
+  accounts: ['197171649850', '935122746343']


### PR DESCRIPTION
Added two account ids which are observed to be associated with Wiz.  Account ID: 935122746343 is seen accessing EBS volumes and Account Id 197171649850 is seen assuming Wiz named roles in multiple accounts across varied customers.