### PR TITLE
Pick up the fix for PyYAML under Cython 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pylint==2.11.1
 pyparsing==3.0.4
 python-dateutil==2.8.2
 pytz==2021.3
-PyYAML==6.0
+PyYAML==6.0.2
 requests==2.26.0
 s3transfer==0.5.0
 scipy==1.10.0


### PR DESCRIPTION
Picks up the fix in https://github.com/yaml/pyyaml/releases/tag/6.0.2

Without this, I get the following error during build (on Python 3.7.17, Python 3.8.20):

```
Collecting PyYAML==6.0
  Using cached PyYAML-6.0.tar.gz (124 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [48 lines of output]
      running egg_info
      writing lib/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/Users/simon/misc/cloudmapper/venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/simon/misc/cloudmapper/venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/Users/simon/misc/cloudmapper/venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 303, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 319, in run_setup
          exec(code, locals())
        File "<string>", line 288, in <module>
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 183, in setup
          return run_commands(dist)
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 199, in run_commands
          dist.run_commands()
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 954, in run_commands
          self.run_command(cmd)
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 999, in run_command
          super().run_command(command)
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 973, in run_command
          cmd_obj.run()
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 312, in run
          self.find_sources()
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 320, in find_sources
          mm.run()
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 541, in run
          self.add_defaults()
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 579, in add_defaults
          sdist.add_defaults(self)
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/command/sdist.py", line 109, in add_defaults
          super().add_defaults()
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/sdist.py", line 238, in add_defaults
          self._add_defaults_ext()
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/_distutils/command/sdist.py", line 323, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "<string>", line 204, in get_source_files
        File "/private/var/folders/0w/bxd_wv6510bb2c2l1mfvhgz80000gn/T/pip-build-env-4ifmxb82/overlay/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
```