### PR TITLE
Update Python version requirement and bump pyjq to 2.6.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you want to add your own private commands, you can create a `private_commands
 ## Installation
 
 Requirements:
-- python 3 (3.7.0rc1 is known to work), `pip`, and `virtualenv`
+- python 3 (3.10 is known to work), `pip`, and `virtualenv`
 - You will also need `jq` (https://stedolan.github.io/jq/) and the library `pyjq` (https://github.com/doloopwhile/pyjq), which require some additional tools installed that will be shown.
 
 On macOS:
@@ -60,7 +60,7 @@ git clone https://github.com/duo-labs/cloudmapper.git
 # Install pre-reqs for pyjq
 brew install autoconf automake awscli freetype jq libtool python3
 cd cloudmapper/
-python3 -m venv ./venv && source venv/bin/activate
+python3.10 -m venv ./venv && source venv/bin/activate
 pip install --prefer-binary -r requirements.txt
 ```
 
@@ -74,7 +74,7 @@ git clone https://github.com/duo-labs/cloudmapper.git
 # You may additionally need "build-essential"
 sudo apt-get install autoconf automake libtool python3.7-dev python3-tk jq awscli
 cd cloudmapper/
-python3 -m venv ./venv && source venv/bin/activate
+python3.10 -m venv ./venv && source venv/bin/activate
 pip install -r requirements.txt
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ platformdirs==2.4.0
 policyuniverse==1.4.0.20210819
 pycodestyle==2.8.0
 pyflakes==2.4.0
-pyjq==2.4.0
+pyjq==2.6.0
 pylint==2.11.1
 pyparsing==3.0.4
 python-dateutil==2.8.2


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to reflect the use of Python 3.10 for setting up the virtual environment instead of Python 3.7.

Key changes:

* Updated the Python version requirement from 3.7.0rc1 to 3.10 in the installation requirements section.
* Changed the command to create a virtual environment to use Python 3.10 in the macOS setup instructions.
* Updated the command to create a virtual environment to use Python 3.10 in the Ubuntu setup instructions.…d requirements